### PR TITLE
feat: add connection error handling with friendly messages

### DIFF
--- a/src/ptouch/__init__.py
+++ b/src/ptouch/__init__.py
@@ -27,7 +27,7 @@ from .config import (
     USB_PRODUCT_ID_PT_P900W,
     USB_VENDOR_ID,
 )
-from .connection import Connection, ConnectionNetwork, ConnectionUSB
+from .connection import Connection, ConnectionNetwork, ConnectionUSB, PrinterConnectionError
 from .label import Align, Label, TextLabel
 from .printer import LabelPrinter, MediaType
 from .printers import PTE550W, PTP750W, PTP900
@@ -60,6 +60,7 @@ __all__ = [
     "Connection",
     "ConnectionUSB",
     "ConnectionNetwork",
+    "PrinterConnectionError",
     # Printers
     "LabelPrinter",
     "PTE550W",

--- a/src/ptouch/connection.py
+++ b/src/ptouch/connection.py
@@ -4,6 +4,7 @@
 
 """Connection classes for Brother P-touch printers."""
 
+import errno
 import socket
 from abc import ABC, abstractmethod
 from typing import Any
@@ -12,6 +13,22 @@ import usb.core
 import usb.util
 
 from .config import USB_VENDOR_ID
+
+
+class PrinterConnectionError(Exception):
+    """Exception raised when connection to printer fails.
+
+    Parameters
+    ----------
+    message : str
+        Human-readable error message.
+    original_error : Exception, optional
+        The underlying exception that caused this error.
+    """
+
+    def __init__(self, message: str, original_error: Exception | None = None) -> None:
+        super().__init__(message)
+        self.original_error = original_error
 
 
 class Connection(ABC):
@@ -66,22 +83,37 @@ class ConnectionUSB(Connection):
 
     Raises
     ------
-    ValueError
-        If the printer device is not found or endpoints are missing.
+    PrinterConnectionError
+        If the printer device is not found, endpoints are missing, or USB access fails.
     """
 
     def __init__(self, product_id: int) -> None:
         self._device: Any = usb.core.find(idVendor=USB_VENDOR_ID, idProduct=product_id)
         if self._device is None:
-            raise ValueError("Printer device not found.")
+            raise PrinterConnectionError(
+                f"USB printer with product ID 0x{product_id:04X} not found. "
+                "Check if the printer is connected and powered on."
+            )
 
         self._kernel_driver_detached = False
-        interface = self._device[0].interfaces()[0]
-        if self._device.is_kernel_driver_active(interface.bInterfaceNumber):
-            self._device.detach_kernel_driver(interface.bInterfaceNumber)
-            self._kernel_driver_detached = True
+        try:
+            interface = self._device[0].interfaces()[0]
+            if self._device.is_kernel_driver_active(interface.bInterfaceNumber):
+                self._device.detach_kernel_driver(interface.bInterfaceNumber)
+                self._kernel_driver_detached = True
 
-        self._device.set_configuration()
+            self._device.set_configuration()
+        except usb.core.USBError as e:
+            if e.errno == errno.EACCES:
+                raise PrinterConnectionError(
+                    "Permission denied accessing USB printer. "
+                    "Try running with sudo or configure udev rules.",
+                    original_error=e,
+                ) from e
+            raise PrinterConnectionError(
+                f"Failed to initialize USB printer: {e}",
+                original_error=e,
+            ) from e
 
         cfg = self._device.get_active_configuration()
         intf = usb.util.find_descriptor(cfg, bInterfaceClass=7)
@@ -97,7 +129,9 @@ class ConnectionUSB(Connection):
         self._ep_out: Any = usb.util.find_descriptor(intf, custom_match=match_endpoint_out)
 
         if self._ep_in is None or self._ep_out is None:
-            raise ValueError("USB endpoints not found.")
+            raise PrinterConnectionError(
+                "USB endpoints not found. The device may not be a supported printer."
+            )
 
     def write(self, payload: bytes) -> None:
         """Write data to the printer via USB."""
@@ -124,24 +158,104 @@ class ConnectionNetwork(Connection):
         Hostname or IP address of the printer.
     port : int, default 9100
         TCP port number for raw printing.
+    timeout : float, default 5.0
+        Connection timeout in seconds. Also used for read/write operations.
+
+    Raises
+    ------
+    PrinterConnectionError
+        If the printer cannot be reached or connection fails.
     """
 
-    def __init__(self, host: str, port: int = 9100) -> None:
+    def __init__(self, host: str, port: int = 9100, timeout: float = 5.0) -> None:
         self.host = host
         self.port = port
+        self.timeout = timeout
         self._socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         # Disable Nagle's algorithm to send packets immediately
         self._socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
-        self._socket.connect((self.host, self.port))
-        self._socket.setblocking(True)
+        self._socket.settimeout(timeout)
+
+        try:
+            self._socket.connect((self.host, self.port))
+        except socket.timeout as e:
+            self._socket.close()
+            raise PrinterConnectionError(
+                f"Connection to printer at {host}:{port} timed out after {timeout}s",
+                original_error=e,
+            ) from e
+        except ConnectionRefusedError as e:
+            self._socket.close()
+            raise PrinterConnectionError(
+                f"Connection refused by printer at {host}:{port}. "
+                "Check if the printer is powered on and accepts network connections.",
+                original_error=e,
+            ) from e
+        except socket.gaierror as e:
+            self._socket.close()
+            raise PrinterConnectionError(
+                f"Cannot resolve hostname '{host}'. "
+                "Check if the hostname or IP address is correct.",
+                original_error=e,
+            ) from e
+        except OSError as e:
+            self._socket.close()
+            raise PrinterConnectionError(
+                f"Failed to connect to printer at {host}:{port}: {e}",
+                original_error=e,
+            ) from e
 
     def write(self, payload: bytes) -> None:
-        """Write data to the printer via network."""
-        self._socket.sendall(payload)
+        """Write data to the printer via network.
+
+        Raises
+        ------
+        PrinterConnectionError
+            If writing to the printer fails or times out.
+        """
+        try:
+            self._socket.sendall(payload)
+        except socket.timeout as e:
+            raise PrinterConnectionError(
+                f"Write to printer at {self.host}:{self.port} timed out",
+                original_error=e,
+            ) from e
+        except (BrokenPipeError, ConnectionResetError) as e:
+            raise PrinterConnectionError(
+                f"Connection to printer at {self.host}:{self.port} was lost",
+                original_error=e,
+            ) from e
+        except OSError as e:
+            raise PrinterConnectionError(
+                f"Failed to write to printer at {self.host}:{self.port}: {e}",
+                original_error=e,
+            ) from e
 
     def read(self, num_bytes: int = 1024) -> bytes:
-        """Read data from the printer via network."""
-        return self._socket.recv(num_bytes)
+        """Read data from the printer via network.
+
+        Raises
+        ------
+        PrinterConnectionError
+            If reading from the printer fails or times out.
+        """
+        try:
+            return self._socket.recv(num_bytes)
+        except socket.timeout as e:
+            raise PrinterConnectionError(
+                f"Read from printer at {self.host}:{self.port} timed out",
+                original_error=e,
+            ) from e
+        except (BrokenPipeError, ConnectionResetError) as e:
+            raise PrinterConnectionError(
+                f"Connection to printer at {self.host}:{self.port} was lost",
+                original_error=e,
+            ) from e
+        except OSError as e:
+            raise PrinterConnectionError(
+                f"Failed to read from printer at {self.host}:{self.port}: {e}",
+                original_error=e,
+            ) from e
 
     def close(self) -> None:
         """Close the network connection."""

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,0 +1,202 @@
+# SPDX-FileCopyrightText: 2024-2026 Nicolai Buchwitz <nb@tipi-net.de>
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Tests for the ptouch.connection module."""
+
+import socket
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ptouch.connection import ConnectionNetwork, PrinterConnectionError
+
+
+class TestPrinterConnectionError:
+    """Test PrinterConnectionError exception."""
+
+    def test_exception_message(self) -> None:
+        """Test that exception stores message correctly."""
+        error = PrinterConnectionError("Test error message")
+        assert str(error) == "Test error message"
+        assert error.original_error is None
+
+    def test_exception_with_original_error(self) -> None:
+        """Test that exception stores original error."""
+        original = ValueError("Original error")
+        error = PrinterConnectionError("Wrapped error", original_error=original)
+        assert str(error) == "Wrapped error"
+        assert error.original_error is original
+
+    def test_exception_is_importable_from_package(self) -> None:
+        """Test that PrinterConnectionError can be imported from ptouch."""
+        from ptouch import PrinterConnectionError as ImportedError
+
+        assert ImportedError is PrinterConnectionError
+
+
+class TestConnectionNetworkInit:
+    """Test ConnectionNetwork initialization and error handling."""
+
+    def test_timeout_parameter_stored(self) -> None:
+        """Test that timeout parameter is stored."""
+        with patch("socket.socket") as mock_socket:
+            mock_sock = MagicMock()
+            mock_socket.return_value = mock_sock
+
+            conn = ConnectionNetwork("192.168.1.100", timeout=10.0)
+
+            assert conn.timeout == 10.0
+            mock_sock.settimeout.assert_called_with(10.0)
+
+    def test_default_timeout(self) -> None:
+        """Test that default timeout is 5.0 seconds."""
+        with patch("socket.socket") as mock_socket:
+            mock_sock = MagicMock()
+            mock_socket.return_value = mock_sock
+
+            conn = ConnectionNetwork("192.168.1.100")
+
+            assert conn.timeout == 5.0
+            mock_sock.settimeout.assert_called_with(5.0)
+
+    def test_connection_timeout_raises_printer_error(self) -> None:
+        """Test that connection timeout raises PrinterConnectionError."""
+        with patch("socket.socket") as mock_socket:
+            mock_sock = MagicMock()
+            mock_socket.return_value = mock_sock
+            mock_sock.connect.side_effect = socket.timeout("timed out")
+
+            with pytest.raises(PrinterConnectionError) as exc_info:
+                ConnectionNetwork("192.168.1.100", timeout=5.0)
+
+            assert "timed out" in str(exc_info.value)
+            assert "192.168.1.100:9100" in str(exc_info.value)
+            assert isinstance(exc_info.value.original_error, socket.timeout)
+            mock_sock.close.assert_called_once()
+
+    def test_connection_refused_raises_printer_error(self) -> None:
+        """Test that connection refused raises PrinterConnectionError."""
+        with patch("socket.socket") as mock_socket:
+            mock_sock = MagicMock()
+            mock_socket.return_value = mock_sock
+            mock_sock.connect.side_effect = ConnectionRefusedError("Connection refused")
+
+            with pytest.raises(PrinterConnectionError) as exc_info:
+                ConnectionNetwork("192.168.1.100")
+
+            assert "refused" in str(exc_info.value).lower()
+            assert "192.168.1.100:9100" in str(exc_info.value)
+            assert isinstance(exc_info.value.original_error, ConnectionRefusedError)
+            mock_sock.close.assert_called_once()
+
+    def test_hostname_resolution_error_raises_printer_error(self) -> None:
+        """Test that hostname resolution failure raises PrinterConnectionError."""
+        with patch("socket.socket") as mock_socket:
+            mock_sock = MagicMock()
+            mock_socket.return_value = mock_sock
+            mock_sock.connect.side_effect = socket.gaierror(8, "Name not resolved")
+
+            with pytest.raises(PrinterConnectionError) as exc_info:
+                ConnectionNetwork("invalid.hostname.local")
+
+            assert "invalid.hostname.local" in str(exc_info.value)
+            assert "resolve" in str(exc_info.value).lower()
+            assert isinstance(exc_info.value.original_error, socket.gaierror)
+            mock_sock.close.assert_called_once()
+
+    def test_generic_os_error_raises_printer_error(self) -> None:
+        """Test that generic OSError raises PrinterConnectionError."""
+        with patch("socket.socket") as mock_socket:
+            mock_sock = MagicMock()
+            mock_socket.return_value = mock_sock
+            mock_sock.connect.side_effect = OSError("Network unreachable")
+
+            with pytest.raises(PrinterConnectionError) as exc_info:
+                ConnectionNetwork("192.168.1.100")
+
+            assert "192.168.1.100:9100" in str(exc_info.value)
+            assert isinstance(exc_info.value.original_error, OSError)
+            mock_sock.close.assert_called_once()
+
+
+class TestConnectionNetworkWrite:
+    """Test ConnectionNetwork write method error handling."""
+
+    @pytest.fixture
+    def connected_network(self) -> ConnectionNetwork:
+        """Create a ConnectionNetwork with mocked socket."""
+        with patch("socket.socket") as mock_socket:
+            mock_sock = MagicMock()
+            mock_socket.return_value = mock_sock
+            conn = ConnectionNetwork("192.168.1.100")
+            return conn
+
+    def test_write_timeout_raises_printer_error(self, connected_network: ConnectionNetwork) -> None:
+        """Test that write timeout raises PrinterConnectionError."""
+        connected_network._socket.sendall.side_effect = socket.timeout("timed out")
+
+        with pytest.raises(PrinterConnectionError) as exc_info:
+            connected_network.write(b"test data")
+
+        assert "timed out" in str(exc_info.value).lower()
+        assert isinstance(exc_info.value.original_error, socket.timeout)
+
+    def test_write_broken_pipe_raises_printer_error(
+        self, connected_network: ConnectionNetwork
+    ) -> None:
+        """Test that broken pipe raises PrinterConnectionError."""
+        connected_network._socket.sendall.side_effect = BrokenPipeError("Broken pipe")
+
+        with pytest.raises(PrinterConnectionError) as exc_info:
+            connected_network.write(b"test data")
+
+        assert "lost" in str(exc_info.value).lower()
+        assert isinstance(exc_info.value.original_error, BrokenPipeError)
+
+    def test_write_connection_reset_raises_printer_error(
+        self, connected_network: ConnectionNetwork
+    ) -> None:
+        """Test that connection reset raises PrinterConnectionError."""
+        connected_network._socket.sendall.side_effect = ConnectionResetError("Connection reset")
+
+        with pytest.raises(PrinterConnectionError) as exc_info:
+            connected_network.write(b"test data")
+
+        assert "lost" in str(exc_info.value).lower()
+        assert isinstance(exc_info.value.original_error, ConnectionResetError)
+
+
+class TestConnectionNetworkRead:
+    """Test ConnectionNetwork read method error handling."""
+
+    @pytest.fixture
+    def connected_network(self) -> ConnectionNetwork:
+        """Create a ConnectionNetwork with mocked socket."""
+        with patch("socket.socket") as mock_socket:
+            mock_sock = MagicMock()
+            mock_socket.return_value = mock_sock
+            conn = ConnectionNetwork("192.168.1.100")
+            return conn
+
+    def test_read_timeout_raises_printer_error(self, connected_network: ConnectionNetwork) -> None:
+        """Test that read timeout raises PrinterConnectionError."""
+        connected_network._socket.recv.side_effect = socket.timeout("timed out")
+
+        with pytest.raises(PrinterConnectionError) as exc_info:
+            connected_network.read()
+
+        assert "timed out" in str(exc_info.value).lower()
+        assert isinstance(exc_info.value.original_error, socket.timeout)
+
+    def test_read_broken_pipe_raises_printer_error(
+        self, connected_network: ConnectionNetwork
+    ) -> None:
+        """Test that broken pipe raises PrinterConnectionError."""
+        connected_network._socket.recv.side_effect = BrokenPipeError("Broken pipe")
+
+        with pytest.raises(PrinterConnectionError) as exc_info:
+            connected_network.read()
+
+        assert "lost" in str(exc_info.value).lower()
+        assert isinstance(exc_info.value.original_error, BrokenPipeError)


### PR DESCRIPTION
## Summary
- Add `PrinterConnectionError` exception with `original_error` attribute for debugging
- Add `timeout` parameter to `ConnectionNetwork` (default 5 seconds)
- Wrap socket and USB errors with user-friendly messages:
  - Connection timeout, refused, DNS resolution failures
  - Write/read timeouts and connection lost errors
  - USB permission denied with helpful hints (sudo/udev)

## Test plan
- [x] All 116 tests pass
- [x] Linting passes
- [x] Manual test with unreachable printer IP
- [x] Manual test with invalid hostname