### PR TITLE
docs: update CLI examples to use ptouch command

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,35 +109,37 @@ Then add the corresponding `TapeConfig` entries to each printer class that suppo
 
 ### Command Line
 
+When the package is installed, the `ptouch` command is available (or use `python -m ptouch` when running from source):
+
 ```bash
 # Print text label via network (uses PIL default font)
-python -m ptouch "Hello World" --host 192.168.1.100 --printer P900 --tape-width 36
+ptouch "Hello World" --host 192.168.1.100 --printer P900 --tape-width 36
 
 # Print with custom font
-python -m ptouch "Hello World" --host 192.168.1.100 --printer P900 \
+ptouch "Hello World" --host 192.168.1.100 --printer P900 \
     --tape-width 36 --font /path/to/font.ttf
 
 # Print multiple labels (half-cut between, full cut after last)
-python -m ptouch "Label 1" "Label 2" "Label 3" --host 192.168.1.100 \
+ptouch "Label 1" "Label 2" "Label 3" --host 192.168.1.100 \
     --printer P900 --tape-width 12
 
 # Print multiple labels with full cuts between each
-python -m ptouch "Label 1" "Label 2" --full-cut --host 192.168.1.100 \
+ptouch "Label 1" "Label 2" --full-cut --host 192.168.1.100 \
     --printer P900 --tape-width 12
 
 # Print image label via USB
-python -m ptouch --image logo.png --usb --printer E550W --tape-width 12
+ptouch --image logo.png --usb --printer E550W --tape-width 12
 
 # Print with fixed font size (disables auto-sizing)
-python -m ptouch "Test" --host 192.168.1.100 --printer P900 --tape-width 24 \
+ptouch "Test" --host 192.168.1.100 --printer P900 --tape-width 24 \
     --font-size 48 --high-resolution --align left top --margin 5
 
 # Print 5 copies of a label
-python -m ptouch "Asset Tag" --copies 5 --host 192.168.1.100 \
+ptouch "Asset Tag" --copies 5 --host 192.168.1.100 \
     --printer P900 --tape-width 12
 
 # Print label with fixed width (50mm)
-python -m ptouch "Short" --width 50 --host 192.168.1.100 \
+ptouch "Short" --width 50 --host 192.168.1.100 \
     --printer P900 --tape-width 12
 ```
 
@@ -252,10 +254,10 @@ Note: `Align` is also available as a backwards-compatible alias at package level
 ## CLI Options
 
 ```
-usage: python -m ptouch [-h] [--image FILE] (--host IP | --usb) --printer {E550W,P750W,P900,P900W,P950NW}
-                        --tape-width {6,9,12,18,24,36} [--font PATH] [--font-size PX]
-                        [--align H V] [--high-resolution] [--margin MM] [--no-compression]
-                        [--full-cut] [text ...]
+usage: ptouch [-h] [--image FILE] (--host IP | --usb) --printer {E550W,P750W,P900,P900W,P950NW}
+              --tape-width {6,9,12,18,24,36} [--font PATH] [--font-size PX]
+              [--align H V] [--high-resolution] [--margin MM] [--no-compression]
+              [--full-cut] [--copies N] [--width MM] [text ...]
 
 positional arguments:
   text                  Text to print. Multiple strings create multiple labels

--- a/src/ptouch/__main__.py
+++ b/src/ptouch/__main__.py
@@ -64,35 +64,35 @@ ALIGN_VERTICAL = {
 def parse_args() -> argparse.Namespace:
     """Parse command line arguments."""
     parser = argparse.ArgumentParser(
-        prog="python -m ptouch",
+        prog="ptouch",
         description="Print labels on Brother P-touch printers.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""\
 Examples:
   # Print text label via network (uses PIL default font)
-  python -m ptouch "Hello World" --host 192.168.1.100 --printer P900 --tape-width 36
+  ptouch "Hello World" --host 192.168.1.100 --printer P900 --tape-width 36
 
   # Print with custom font
-  python -m ptouch "Hello World" --host 192.168.1.100 --printer P900 \\
+  ptouch "Hello World" --host 192.168.1.100 --printer P900 \\
       --tape-width 36 --font /path/to/font.ttf
 
   # Print multiple labels (half-cut between, full cut after last)
-  python -m ptouch "Label 1" "Label 2" "Label 3" --host 192.168.1.100 \\
+  ptouch "Label 1" "Label 2" "Label 3" --host 192.168.1.100 \\
       --printer E550W --tape-width 12
 
   # Print image label via USB
-  python -m ptouch --image logo.png --usb --printer E550W --tape-width 12
+  ptouch --image logo.png --usb --printer E550W --tape-width 12
 
   # Print with fixed font size (disables auto-sizing)
-  python -m ptouch "Test" --host 192.168.1.100 --printer P900 \\
+  ptouch "Test" --host 192.168.1.100 --printer P900 \\
       --tape-width 24 --font-size 48 --high-resolution
 
   # Print 5 copies of a label
-  python -m ptouch "Asset Tag" --copies 5 --host 192.168.1.100 \\
+  ptouch "Asset Tag" --copies 5 --host 192.168.1.100 \\
       --printer P900 --tape-width 12
 
   # Print label with fixed width (50mm)
-  python -m ptouch "Short" --width 50 --host 192.168.1.100 \\
+  ptouch "Short" --width 50 --host 192.168.1.100 \\
       --printer P900 --tape-width 12
 """,
     )


### PR DESCRIPTION
## Summary
- Update CLI program name from `python -m ptouch` to `ptouch`
- Update all examples in README and help text
- Add note that `python -m ptouch` can be used when running from source

## Test plan
- [x] `ptouch --help` shows correct program name
- [x] Examples in README use `ptouch` command