### PR TITLE
feat: add separate printer classes for P900 series variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Python library for Brother P-touch label printers.
 
 ## Features
 
-- Support for Brother P-touch label printers (PT-E550W, PT-P750W, PT-P900W, PT-P950NW)
+- Support for Brother P-touch label printers (PT-E550W, PT-P750W, PT-P900, PT-P900W, PT-P910BT, PT-P950NW)
 - Network (TCP/IP) and USB connections
 - Text labels with customizable fonts and alignment
 - Image label printing
@@ -38,8 +38,10 @@ For USB support:
 |---------|------------|----------|------|----------------|-------|
 | PT-E550W | 180 DPI | 360 DPI | 128 | 24mm | `PTE550W` |
 | PT-P750W | 180 DPI | 360 DPI | 128 | 24mm | `PTP750W` |
-| PT-P900W | 360 DPI | 720 DPI | 560 | 36mm | `PTP900` |
-| PT-P950NW | 360 DPI | 720 DPI | 560 | 36mm | `PTP900` |
+| PT-P900 | 360 DPI | 720 DPI | 560 | 36mm | `PTP900` |
+| PT-P900W | 360 DPI | 720 DPI | 560 | 36mm | `PTP900W` |
+| PT-P910BT | 360 DPI | 720 DPI | 560 | 36mm | `PTP910BT` |
+| PT-P950NW | 360 DPI | 720 DPI | 560 | 36mm | `PTP950NW` |
 
 ### Tapes
 

--- a/src/ptouch/__init__.py
+++ b/src/ptouch/__init__.py
@@ -11,12 +11,15 @@ compression, and printer-specific command sequences.
 Supported printers:
     - PT-E550W (128 pins, 180 DPI)
     - PT-P750W (128 pins, 180 DPI)
-    - PT-P900W / P900Wc (560 pins, 360 DPI)
+    - PT-P900 (560 pins, 360 DPI)
+    - PT-P900W (560 pins, 360 DPI)
+    - PT-P910BT (560 pins, 360 DPI)
+    - PT-P950NW (560 pins, 360 DPI)
 
 Example usage:
-    >>> from ptouch import PTP900, ConnectionNetwork, LaminatedTape36mm, TextLabel
+    >>> from ptouch import PTP900W, ConnectionNetwork, LaminatedTape36mm, TextLabel
     >>> conn = ConnectionNetwork("192.168.1.100")
-    >>> printer = PTP900(conn)
+    >>> printer = PTP900W(conn)
     >>> label = TextLabel("Hello, World!", LaminatedTape36mm)
     >>> printer.print(label)
 """
@@ -24,7 +27,7 @@ Example usage:
 from .connection import Connection, ConnectionNetwork, ConnectionUSB, PrinterConnectionError
 from .label import Align, Label, TextLabel
 from .printer import LabelPrinter, MediaType, TapeConfig
-from .printers import PTE550W, PTP750W, PTP900
+from .printers import PTE550W, PTP750W, PTP900, PTP900W, PTP910BT, PTP950NW
 from .tape import (
     HeatShrinkTape,
     LaminatedTape,
@@ -57,6 +60,9 @@ __all__ = [
     "PTE550W",
     "PTP750W",
     "PTP900",
+    "PTP900W",
+    "PTP910BT",
+    "PTP950NW",
     # Tapes
     "Tape",
     "LaminatedTape",

--- a/src/ptouch/__main__.py
+++ b/src/ptouch/__main__.py
@@ -24,6 +24,9 @@ from . import (
     PTE550W,
     PTP750W,
     PTP900,
+    PTP900W,
+    PTP910BT,
+    PTP950NW,
     TextLabel,
 )
 from .printer import LabelPrinter
@@ -43,8 +46,9 @@ PRINTER_TYPES = {
     "E550W": PTE550W,
     "P750W": PTP750W,
     "P900": PTP900,
-    "P900W": PTP900,
-    "P950NW": PTP900,
+    "P900W": PTP900W,
+    "P910BT": PTP910BT,
+    "P950NW": PTP950NW,
 }
 
 # Mapping of alignment strings to Align flags

--- a/src/ptouch/printers.py
+++ b/src/ptouch/printers.py
@@ -50,15 +50,13 @@ class PTP750W(PTE550W):
     USB_PRODUCT_ID = 0x2065
 
 
-class PTP900(LabelPrinter):
-    """Brother PT-P900W/P900Wc label printer (560 pins, 360 DPI).
+class PTP900Series(LabelPrinter):
+    """Base class for Brother PT-P900 series printers (560 pins, 360 DPI).
 
-    This class supports the following printers:
-        - PT-P900W
-        - PT-P900Wc
+    This is the base class for all P900 series printers. Use one of the
+    specific subclasses (PTP900, PTP900W, PTP950NW, PTP910BT) instead.
     """
 
-    USB_PRODUCT_ID = 0x2085
     TOTAL_PINS = 560
     BYTES_PER_LINE = 70
     RESOLUTION_DPI = 360
@@ -75,3 +73,27 @@ class PTP900(LabelPrinter):
         LaminatedTape24mm: TapeConfig(left_pins=112, print_pins=320, right_pins=128),
         LaminatedTape36mm: TapeConfig(left_pins=45, print_pins=454, right_pins=61),
     }
+
+
+class PTP900(PTP900Series):
+    """Brother PT-P900 label printer (USB only, no wireless)."""
+
+    USB_PRODUCT_ID = 0x2083
+
+
+class PTP900W(PTP900Series):
+    """Brother PT-P900W label printer (with Wi-Fi)."""
+
+    USB_PRODUCT_ID = 0x2085
+
+
+class PTP950NW(PTP900Series):
+    """Brother PT-P950NW label printer (with network connectivity)."""
+
+    USB_PRODUCT_ID = 0x2086
+
+
+class PTP910BT(PTP900Series):
+    """Brother PT-P910BT label printer (with Bluetooth)."""
+
+    USB_PRODUCT_ID = 0x20C7

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,7 +6,7 @@
 
 from ptouch.connection import USB_VENDOR_ID
 from ptouch.printer import TapeConfig
-from ptouch.printers import PTE550W, PTP750W, PTP900
+from ptouch.printers import PTE550W, PTP750W, PTP900, PTP900W, PTP910BT, PTP950NW
 
 
 class TestTapeConfig:
@@ -65,9 +65,21 @@ class TestUSBConstants:
         """Test PT-P750W product ID."""
         assert PTP750W.USB_PRODUCT_ID == 0x2065
 
+    def test_usb_product_id_p900(self) -> None:
+        """Test PT-P900 product ID."""
+        assert PTP900.USB_PRODUCT_ID == 0x2083
+
     def test_usb_product_id_p900w(self) -> None:
         """Test PT-P900W product ID."""
-        assert PTP900.USB_PRODUCT_ID == 0x2085
+        assert PTP900W.USB_PRODUCT_ID == 0x2085
+
+    def test_usb_product_id_p910bt(self) -> None:
+        """Test PT-P910BT product ID."""
+        assert PTP910BT.USB_PRODUCT_ID == 0x20C7
+
+    def test_usb_product_id_p950nw(self) -> None:
+        """Test PT-P950NW product ID."""
+        assert PTP950NW.USB_PRODUCT_ID == 0x2086
 
     def test_vendor_and_product_ids_are_different(self) -> None:
         """Test that vendor and product IDs are all different."""
@@ -76,5 +88,8 @@ class TestUSBConstants:
             PTE550W.USB_PRODUCT_ID,
             PTP750W.USB_PRODUCT_ID,
             PTP900.USB_PRODUCT_ID,
+            PTP900W.USB_PRODUCT_ID,
+            PTP910BT.USB_PRODUCT_ID,
+            PTP950NW.USB_PRODUCT_ID,
         ]
         assert len(ids) == len(set(ids))


### PR DESCRIPTION
## Summary

- Create `PTP900Series` base class for common P900 settings
- Add `PTP900` (0x2083) for USB-only model
- Add `PTP900W` (0x2085) for Wi-Fi model  
- Add `PTP910BT` (0x20C7) for Bluetooth model
- Add `PTP950NW` (0x2086) for network model
- Update CLI to support all variants
- Update README with new printer classes

## Test plan

- [x] All 127 tests pass
- [x] Linter passes
- [x] Manual test with P900W via USB