### PR TITLE
feat: add support for 3.5mm laminated tape

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Comprehensive documentation is available at [ptouch.readthedocs.io](https://ptou
 
 | Type | Widths | Class |
 |------|--------|-------|
-| Laminated (TZe) | 3.5mm, 6mm, 9mm, 12mm, 18mm, 24mm, 36mm | `LaminatedTape*mm` |
+| TZe | 3.5mm, 6mm, 9mm, 12mm, 18mm, 24mm, 36mm | `Tape*mm` |
 
 ## Adding Support for New Devices
 
@@ -68,7 +68,7 @@ To add support for a new P-touch printer, create a subclass of `LabelPrinter` in
 
 ```python
 from ptouch.printer import LabelPrinter, TapeConfig
-from ptouch.tape import LaminatedTape12mm, LaminatedTape24mm  # etc.
+from ptouch.tape import Tape12mm, Tape24mm  # etc.
 
 class PTP710BT(LabelPrinter):
     """Brother PT-P710BT label printer."""
@@ -97,8 +97,8 @@ class PTP710BT(LabelPrinter):
     # Pin configuration for each tape width
     # Values from Brother raster command reference PDF
     PIN_CONFIGS = {
-        LaminatedTape12mm: TapeConfig(left_pins=29, print_pins=70, right_pins=29),
-        LaminatedTape24mm: TapeConfig(left_pins=0, print_pins=128, right_pins=0),
+        Tape12mm: TapeConfig(left_pins=29, print_pins=70, right_pins=29),
+        Tape24mm: TapeConfig(left_pins=0, print_pins=128, right_pins=0),
         # Add more tape sizes as needed
     }
 ```
@@ -108,13 +108,13 @@ Brother raster command reference documentation for your printer model.
 
 ### Adding a New Tape Type
 
-To add a new tape type, create a subclass of `Tape` or `LaminatedTape` in `ptouch/tape.py`:
+To add a new tape type, create a subclass of `Tape` in `ptouch/tape.py`:
 
 ```python
-from ptouch.tape import LaminatedTape
+from ptouch.tape import Tape
 
-class LaminatedTape48mm(LaminatedTape):
-    """48mm laminated tape."""
+class Tape48mm(Tape):
+    """48mm tape."""
     width_mm = 48
 ```
 
@@ -167,7 +167,7 @@ from ptouch import (
     ConnectionNetwork,
     PTP900,
     TextLabel,
-    LaminatedTape36mm,
+    Tape36mm,
 )
 
 # Connect to printer
@@ -177,7 +177,7 @@ printer = PTP900(connection, high_resolution=True)
 # Create and print text label
 label = TextLabel(
     "Hello World",
-    LaminatedTape36mm,
+    Tape36mm,
     font="/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
     align=TextLabel.Align.CENTER,
 )
@@ -186,40 +186,40 @@ printer.print(label)
 # Or use a pre-loaded ImageFont (auto-sized by default)
 from PIL import ImageFont
 font = ImageFont.truetype("/path/to/font.ttf", size=48)
-label = TextLabel("Custom Font", LaminatedTape36mm, font=font)
+label = TextLabel("Custom Font", Tape36mm, font=font)
 
 # Use ImageFont with its built-in size (disable auto-sizing)
-label = TextLabel("Fixed Size", LaminatedTape36mm, font=font, auto_size=False)
+label = TextLabel("Fixed Size", Tape36mm, font=font, auto_size=False)
 
 # For quick testing, use the default font (requires Pillow 10.1+)
-label = TextLabel("Quick Test", LaminatedTape36mm, font=ImageFont.load_default())
+label = TextLabel("Quick Test", Tape36mm, font=ImageFont.load_default())
 ```
 
 #### Image Labels
 
 ```python
 from PIL import Image
-from ptouch import ConnectionNetwork, PTP900, Label, LaminatedTape36mm
+from ptouch import ConnectionNetwork, PTP900, Label, Tape36mm
 
 connection = ConnectionNetwork("192.168.1.100")
 printer = PTP900(connection)
 
 image = Image.open("label.png")
-label = Label(image, LaminatedTape36mm)
+label = Label(image, Tape36mm)
 printer.print(label, margin_mm=3.0)
 ```
 
 #### USB Connection
 
 ```python
-from ptouch import ConnectionUSB, PTE550W, TextLabel, LaminatedTape12mm
+from ptouch import ConnectionUSB, PTE550W, TextLabel, Tape12mm
 
 connection = ConnectionUSB()
 printer = PTE550W(connection)
 
 label = TextLabel(
     "USB Label",
-    LaminatedTape12mm,
+    Tape12mm,
     font="/path/to/font.ttf",
 )
 printer.print(label)
@@ -230,15 +230,15 @@ printer.print(label)
 Print multiple labels in a single job with half-cuts between labels to save tape:
 
 ```python
-from ptouch import ConnectionNetwork, PTP900, TextLabel, LaminatedTape12mm
+from ptouch import ConnectionNetwork, PTP900, TextLabel, Tape12mm
 
 connection = ConnectionNetwork("192.168.1.100")
 printer = PTP900(connection)
 
 labels = [
-    TextLabel("Label 1", LaminatedTape12mm, font="/path/to/font.ttf"),
-    TextLabel("Label 2", LaminatedTape12mm, font="/path/to/font.ttf"),
-    TextLabel("Label 3", LaminatedTape12mm, font="/path/to/font.ttf"),
+    TextLabel("Label 1", Tape12mm, font="/path/to/font.ttf"),
+    TextLabel("Label 2", Tape12mm, font="/path/to/font.ttf"),
+    TextLabel("Label 3", Tape12mm, font="/path/to/font.ttf"),
 ]
 
 # Half-cuts between labels (default), full cut after last

--- a/docs/adding_devices.rst
+++ b/docs/adding_devices.rst
@@ -64,11 +64,11 @@ Create a new class in ``src/ptouch/printers.py``:
 
    from ptouch.printer import LabelPrinter, TapeConfig
    from ptouch.tape import (
-       LaminatedTape6mm,
-       LaminatedTape9mm,
-       LaminatedTape12mm,
-       LaminatedTape18mm,
-       LaminatedTape24mm,
+       Tape6mm,
+       Tape9mm,
+       Tape12mm,
+       Tape18mm,
+       Tape24mm,
    )
 
    class PTP710BT(LabelPrinter):
@@ -105,27 +105,27 @@ Create a new class in ``src/ptouch/printers.py``:
        # Pin configuration for each tape width
        # Values from Brother raster command reference
        PIN_CONFIGS = {
-           LaminatedTape6mm: TapeConfig(
+           Tape6mm: TapeConfig(
                left_pins=48,
                print_pins=32,
                right_pins=48
            ),
-           LaminatedTape9mm: TapeConfig(
+           Tape9mm: TapeConfig(
                left_pins=39,
                print_pins=50,
                right_pins=39
            ),
-           LaminatedTape12mm: TapeConfig(
+           Tape12mm: TapeConfig(
                left_pins=29,
                print_pins=70,
                right_pins=29
            ),
-           LaminatedTape18mm: TapeConfig(
+           Tape18mm: TapeConfig(
                left_pins=8,
                print_pins=112,
                right_pins=8
            ),
-           LaminatedTape24mm: TapeConfig(
+           Tape24mm: TapeConfig(
                left_pins=0,
                print_pins=128,
                right_pins=0
@@ -172,7 +172,7 @@ Create tests in ``tests/test_printers.py``:
        printer = PTP710BT(mock_connection)
 
        # Test each tape size
-       config = printer.get_tape_config(LaminatedTape12mm)
+       config = printer.get_tape_config(Tape12mm)
        assert config.left_pins == 29
        assert config.print_pins == 70
        assert config.right_pins == 29
@@ -181,7 +181,7 @@ Create tests in ``tests/test_printers.py``:
    def test_ptp710bt_printing():
        """Test basic printing with PTP710BT."""
        printer = PTP710BT(mock_connection)
-       label = Label(sample_image, LaminatedTape12mm)
+       label = Label(sample_image, Tape12mm)
 
        printer.print(label)
        assert len(mock_connection.data) > 0
@@ -242,7 +242,7 @@ Add to ``src/ptouch/tape.py``:
 
 .. code-block:: python
 
-   class LaminatedTape48mm(LaminatedTape):
+   class Tape48mm(Tape):
        """48mm laminated tape (TZe-481, etc.).
 
        Compatible with larger industrial printers only.
@@ -263,14 +263,14 @@ For non-laminated tape:
            """Tape category identifier."""
            pass
 
-   class NonLaminatedTape(Tape):
+   class NonTape(Tape):
        """Non-laminated (N) series tapes."""
 
        @property
        def category(self) -> str:
            return "non-laminated"
 
-   class NonLaminatedTape12mm(NonLaminatedTape):
+   class NonTape12mm(NonTape):
        """12mm non-laminated tape."""
        width_mm = 12
 
@@ -284,7 +284,7 @@ Update each compatible printer's ``PIN_CONFIGS``:
    class PTP900(PTP900Series):
        PIN_CONFIGS = {
            # ... existing configs ...
-           LaminatedTape48mm: TapeConfig(
+           Tape48mm: TapeConfig(
                left_pins=0,
                print_pins=680,  # Example - check reference manual
                right_pins=0
@@ -312,12 +312,12 @@ Add to ``src/ptouch/__init__.py``:
 
    from .tape import (
        # ... existing imports ...
-       LaminatedTape48mm,
+       Tape48mm,
    )
 
    __all__ = [
        # ... existing exports ...
-       "LaminatedTape48mm",
+       "Tape48mm",
    ]
 
 Test with your printer:
@@ -326,7 +326,7 @@ Test with your printer:
 
    def test_new_tape():
        printer = PTP900(mock_connection)
-       label = Label(sample_image, LaminatedTape48mm)
+       label = Label(sample_image, Tape48mm)
        printer.print(label)
 
 Testing Your Changes
@@ -350,7 +350,7 @@ Test with actual printer:
 
 .. code-block:: python
 
-   from ptouch import ConnectionUSB, PTP710BT, TextLabel, LaminatedTape12mm
+   from ptouch import ConnectionUSB, PTP710BT, TextLabel, Tape12mm
    from PIL import ImageFont
 
    # Test basic functionality
@@ -359,7 +359,7 @@ Test with actual printer:
 
    label = TextLabel(
        "Test Label",
-       LaminatedTape12mm,
+       Tape12mm,
        font=ImageFont.load_default()
    )
 

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -192,7 +192,7 @@ For grayscale images, apply dithering for better results:
    img = img.convert("1", dither=Image.FLOYDSTEINBERG)
 
    # Print
-   label = Label(img.convert("RGB"), LaminatedTape36mm)
+   label = Label(img.convert("RGB"), Tape36mm)
    printer.print(label)
 
 Batch Processing Optimization
@@ -264,7 +264,7 @@ For complete control over raster data:
    from ptouch.printer import LabelPrinter
 
    # Access internal methods (use with caution)
-   tape_config = printer.get_tape_config(LaminatedTape36mm)
+   tape_config = printer.get_tape_config(Tape36mm)
 
    # Generate custom raster data
    # Each line must be tape_config.print_pins bits

--- a/docs/api/label.rst
+++ b/docs/api/label.rst
@@ -20,7 +20,7 @@ Base class for image-based labels. Use this when you have a pre-rendered image.
 **Key attributes:**
 
 * ``image`` - PIL Image object
-* ``tape`` - Tape type (e.g., ``LaminatedTape36mm``)
+* ``tape`` - Tape type (e.g., ``Tape36mm``)
 
 TextLabel
 ~~~~~~~~~
@@ -69,10 +69,10 @@ Image Label
 .. code-block:: python
 
    from PIL import Image
-   from ptouch import Label, LaminatedTape36mm
+   from ptouch import Label, Tape36mm
 
    image = Image.open("logo.png")
-   label = Label(image, LaminatedTape36mm)
+   label = Label(image, Tape36mm)
    printer.print(label)
 
 Text Label with Auto-Sizing
@@ -80,13 +80,13 @@ Text Label with Auto-Sizing
 
 .. code-block:: python
 
-   from ptouch import TextLabel, LaminatedTape36mm
+   from ptouch import TextLabel, Tape36mm
    from PIL import ImageFont
 
    font = ImageFont.load_default()
    label = TextLabel(
        "Hello World",
-       LaminatedTape36mm,
+       Tape36mm,
        font=font,
        align=TextLabel.Align.CENTER
    )
@@ -99,7 +99,7 @@ Text Label with Fixed Size
    font = ImageFont.truetype("/path/to/font.ttf", 48)
    label = TextLabel(
        "Fixed Size",
-       LaminatedTape36mm,
+       Tape36mm,
        font=font,
        auto_size=False,  # Use font's built-in size
        align=TextLabel.Align.LEFT | TextLabel.Align.TOP
@@ -112,7 +112,7 @@ Text Label with Fixed Width
 
    label = TextLabel(
        "Short",
-       LaminatedTape36mm,
+       Tape36mm,
        font=font,
        width_mm=50.0  # Create 50mm wide label
    )
@@ -125,7 +125,7 @@ Custom Alignment
    # Top-left alignment
    label = TextLabel(
        "Top Left",
-       LaminatedTape36mm,
+       Tape36mm,
        font=font,
        align=TextLabel.Align.LEFT | TextLabel.Align.TOP
    )
@@ -133,7 +133,7 @@ Custom Alignment
    # Bottom-right alignment
    label = TextLabel(
        "Bottom Right",
-       LaminatedTape36mm,
+       Tape36mm,
        font=font,
        align=TextLabel.Align.RIGHT | TextLabel.Align.BOTTOM
    )
@@ -141,7 +141,7 @@ Custom Alignment
    # Centered (shorthand)
    label = TextLabel(
        "Centered",
-       LaminatedTape36mm,
+       Tape36mm,
        font=font,
        align=TextLabel.Align.CENTER
    )

--- a/docs/api/tape.rst
+++ b/docs/api/tape.rst
@@ -12,21 +12,21 @@ The tape module provides tape type definitions for Brother P-touch label printer
 Supported Tapes
 ---------------
 
-Laminated Tapes (TZe Series)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+TZe Series Tapes
+~~~~~~~~~~~~~~~~
 
-Laminated tapes are the most common tape type for Brother P-touch printers.
+TZe tapes are the most common tape type for Brother P-touch printers.
 
 Available Widths
 ^^^^^^^^^^^^^^^^
 
-* ``LaminatedTape3_5mm`` - 3.5mm laminated tape
-* ``LaminatedTape6mm`` - 6mm laminated tape
-* ``LaminatedTape9mm`` - 9mm laminated tape
-* ``LaminatedTape12mm`` - 12mm laminated tape
-* ``LaminatedTape18mm`` - 18mm laminated tape
-* ``LaminatedTape24mm`` - 24mm laminated tape
-* ``LaminatedTape36mm`` - 36mm laminated tape (P900 series only)
+* ``Tape3_5mm`` - 3.5mm tape
+* ``Tape6mm`` - 6mm tape
+* ``Tape9mm`` - 9mm tape
+* ``Tape12mm`` - 12mm tape
+* ``Tape18mm`` - 18mm tape
+* ``Tape24mm`` - 24mm tape
+* ``Tape36mm`` - 36mm tape (P900 series only)
 
 Compatibility
 ^^^^^^^^^^^^^
@@ -81,24 +81,24 @@ Specifying Tape Type
 
 .. code-block:: python
 
-   from ptouch import TextLabel, LaminatedTape36mm
+   from ptouch import TextLabel, Tape36mm
    from PIL import ImageFont
 
    # Create label with 36mm tape
    font = ImageFont.load_default()
-   label = TextLabel("Text", LaminatedTape36mm, font=font)
+   label = TextLabel("Text", Tape36mm, font=font)
 
 Checking Tape Compatibility
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: python
 
-   from ptouch import PTE550W, LaminatedTape36mm
+   from ptouch import PTE550W, Tape36mm
 
    printer = PTE550W(connection)
 
    try:
-       config = printer.get_tape_config(LaminatedTape36mm)
+       config = printer.get_tape_config(Tape36mm)
    except KeyError:
        print("This tape is not compatible with this printer")
 
@@ -125,10 +125,10 @@ Example:
 
 .. code-block:: python
 
-   from ptouch.tape import LaminatedTape
+   from ptouch.tape import Tape
 
-   class LaminatedTape48mm(LaminatedTape):
-       """48mm laminated tape."""
+   class Tape48mm(Tape):
+       """48mm tape."""
        width_mm = 48
 
 Then add the pin configuration to your printer class:
@@ -138,7 +138,7 @@ Then add the pin configuration to your printer class:
    from ptouch.printer import TapeConfig
 
    PIN_CONFIGS = {
-       LaminatedTape48mm: TapeConfig(
+       Tape48mm: TapeConfig(
            left_pins=0,
            print_pins=680,
            right_pins=0

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -10,7 +10,7 @@ Create sequential asset tags:
 
 .. code-block:: python
 
-   from ptouch import ConnectionNetwork, PTP900, TextLabel, LaminatedTape12mm
+   from ptouch import ConnectionNetwork, PTP900, TextLabel, Tape12mm
    from PIL import ImageFont
 
    connection = ConnectionNetwork("192.168.1.100")
@@ -22,7 +22,7 @@ Create sequential asset tags:
    for i in range(1, 101):
        label = TextLabel(
            f"ASSET-{i:04d}",
-           LaminatedTape12mm,
+           Tape12mm,
            font=font,
            align=TextLabel.Align.CENTER
        )
@@ -38,7 +38,7 @@ Create matching pairs for cable ends:
 
 .. code-block:: python
 
-   from ptouch import ConnectionUSB, PTE550W, TextLabel, LaminatedTape9mm
+   from ptouch import ConnectionUSB, PTE550W, TextLabel, Tape9mm
    from PIL import ImageFont
 
    connection = ConnectionUSB()
@@ -53,8 +53,8 @@ Create matching pairs for cable ends:
 
    for cable_a, cable_b in cables:
        # Print both ends
-       label_a = TextLabel(cable_a, LaminatedTape9mm, font=font)
-       label_b = TextLabel(cable_b, LaminatedTape9mm, font=font)
+       label_a = TextLabel(cable_a, Tape9mm, font=font)
+       label_b = TextLabel(cable_b, Tape9mm, font=font)
        printer.print_multi([label_a, label_b])
 
 Server Rack Labels
@@ -92,7 +92,7 @@ Create detailed server identification labels:
        return img
 
    # Generate labels
-   from ptouch import Label, LaminatedTape36mm
+   from ptouch import Label, Tape36mm
 
    servers = [
        ("web-prod-01", "10.0.1.10", "R1-U12"),
@@ -103,7 +103,7 @@ Create detailed server identification labels:
    labels = []
    for hostname, ip, location in servers:
        img = create_server_label(hostname, ip, location)
-       labels.append(Label(img, LaminatedTape36mm))
+       labels.append(Label(img, Tape36mm))
 
    printer.print_multi(labels)
 
@@ -167,7 +167,7 @@ Create QR code labels for inventory tracking:
    labels = []
    for item_id, name, location in items:
        img = create_inventory_label(item_id, name, location)
-       labels.append(Label(img, LaminatedTape36mm))
+       labels.append(Label(img, Tape36mm))
 
    printer.print_multi(labels)
 
@@ -213,7 +213,7 @@ Create attention-grabbing warning labels:
        return img
 
    warnings = ["CAUTION", "HIGH VOLTAGE", "DO NOT TOUCH"]
-   labels = [Label(create_warning_label(w), LaminatedTape36mm) for w in warnings]
+   labels = [Label(create_warning_label(w), Tape36mm) for w in warnings]
    printer.print_multi(labels)
 
 Batch Processing from CSV
@@ -224,7 +224,7 @@ Read label data from CSV file:
 .. code-block:: python
 
    import csv
-   from ptouch import TextLabel, LaminatedTape12mm
+   from ptouch import TextLabel, Tape12mm
 
    def process_csv_labels(csv_file, printer):
        labels = []
@@ -238,7 +238,7 @@ Read label data from CSV file:
 
                label = TextLabel(
                    text,
-                   LaminatedTape12mm,
+                   Tape12mm,
                    font=ImageFont.load_default(),
                    width_mm=width_mm
                )
@@ -269,7 +269,7 @@ Generate labels for device configurations:
 .. code-block:: python
 
    import yaml
-   from ptouch import TextLabel, Label, LaminatedTape18mm
+   from ptouch import TextLabel, Label, Tape18mm
    from PIL import Image, ImageDraw, ImageFont
 
    def load_device_config(yaml_file):
@@ -298,7 +298,7 @@ Generate labels for device configurations:
            draw.text((10, y), line, font=font, fill="black")
            y += line_height
 
-       return Label(img, LaminatedTape18mm)
+       return Label(img, Tape18mm)
 
    # Load and print
    config = load_device_config("devices.yaml")
@@ -344,7 +344,7 @@ Create Code39 barcodes (using python-barcode library):
        buffer.seek(0)
        img = Image.open(buffer)
 
-       return Label(img.convert("RGB"), LaminatedTape12mm)
+       return Label(img.convert("RGB"), Tape12mm)
 
    # Generate barcode labels
    codes = ["ABC123", "DEF456", "GHI789"]
@@ -371,15 +371,15 @@ Simple interactive CLI for making labels:
            tape_width = int(tape_width) if tape_width else 12
 
            tape_map = {
-               6: LaminatedTape6mm,
-               9: LaminatedTape9mm,
-               12: LaminatedTape12mm,
-               18: LaminatedTape18mm,
-               24: LaminatedTape24mm,
-               36: LaminatedTape36mm,
+               6: Tape6mm,
+               9: Tape9mm,
+               12: Tape12mm,
+               18: Tape18mm,
+               24: Tape24mm,
+               36: Tape36mm,
            }
 
-           tape = tape_map.get(tape_width, LaminatedTape12mm)
+           tape = tape_map.get(tape_width, Tape12mm)
 
            label = TextLabel(
                text,

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,14 +28,14 @@ Quick Example
 
 .. code-block:: python
 
-   from ptouch import ConnectionNetwork, PTP900, TextLabel, LaminatedTape36mm
+   from ptouch import ConnectionNetwork, PTP900, TextLabel, Tape36mm
    from PIL import ImageFont
 
    connection = ConnectionNetwork("192.168.1.100")
    printer = PTP900(connection, high_resolution=True)
 
    font = ImageFont.load_default()
-   label = TextLabel("Hello World", LaminatedTape36mm, font=font)
+   label = TextLabel("Hello World", Tape36mm, font=font)
    printer.print(label)
 
 Documentation

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -13,7 +13,7 @@ The simplest way to get started is with a network-connected printer:
 
 .. code-block:: python
 
-   from ptouch import ConnectionNetwork, PTP900, TextLabel, LaminatedTape36mm
+   from ptouch import ConnectionNetwork, PTP900, TextLabel, Tape36mm
    from PIL import ImageFont
 
    # Connect to printer
@@ -22,7 +22,7 @@ The simplest way to get started is with a network-connected printer:
 
    # Create text label
    font = ImageFont.load_default()  # Use PIL's default font
-   label = TextLabel("Hello World", LaminatedTape36mm, font=font)
+   label = TextLabel("Hello World", Tape36mm, font=font)
 
    # Print!
    printer.print(label)
@@ -35,7 +35,7 @@ For USB-connected printers:
 
 .. code-block:: python
 
-   from ptouch import ConnectionUSB, PTE550W, TextLabel, LaminatedTape12mm
+   from ptouch import ConnectionUSB, PTE550W, TextLabel, Tape12mm
    from PIL import ImageFont
 
    # Connect via USB (finds first available Brother printer)
@@ -44,7 +44,7 @@ For USB-connected printers:
 
    # Create and print label
    font = ImageFont.load_default()
-   label = TextLabel("Hello USB", LaminatedTape12mm, font=font)
+   label = TextLabel("Hello USB", Tape12mm, font=font)
    printer.print(label)
 
 Using the Command Line
@@ -71,7 +71,7 @@ The library includes a command-line interface:
 Understanding the Basics
 -------------------------
 
-The library provides printer classes for different Brother P-touch models (``PTE550W``, ``PTP750W``, ``PTP900``, etc.) and tape types (``LaminatedTape3_5mm`` through ``LaminatedTape36mm``). See :doc:`api/printer` for complete printer specifications and :doc:`api/tape` for tape compatibility.
+The library provides printer classes for different Brother P-touch models (``PTE550W``, ``PTP750W``, ``PTP900``, etc.) and tape types (``Tape3_5mm`` through ``Tape36mm``). See :doc:`api/printer` for complete printer specifications and :doc:`api/tape` for tape compatibility.
 
 Error Handling
 --------------

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -162,10 +162,10 @@ Misaligned Labels
    .. code-block:: python
 
       # Wrong: Using 12mm tape but specified 24mm
-      label = TextLabel("Text", LaminatedTape24mm, font=font)
+      label = TextLabel("Text", Tape24mm, font=font)
 
       # Correct: Match actual tape in printer
-      label = TextLabel("Text", LaminatedTape12mm, font=font)
+      label = TextLabel("Text", Tape12mm, font=font)
 
 2. **Wrong printer class**
 
@@ -237,7 +237,7 @@ Incomplete Labels
    .. code-block:: python
 
       # For text labels, auto-sizing should work
-      label = TextLabel("Text", LaminatedTape12mm, font=font)  # Auto-sized
+      label = TextLabel("Text", Tape12mm, font=font)  # Auto-sized
 
       # For image labels, ensure image isn't too wide
       max_width_mm = 100  # Adjust based on your needs
@@ -477,11 +477,11 @@ Slow Printing
 
       # Slow: Individual prints
       for text in texts:
-          label = TextLabel(text, LaminatedTape12mm, font=font)
+          label = TextLabel(text, Tape12mm, font=font)
           printer.print(label)
 
       # Fast: Batch printing
-      labels = [TextLabel(t, LaminatedTape12mm, font=font) for t in texts]
+      labels = [TextLabel(t, Tape12mm, font=font) for t in texts]
       printer.print_multi(labels)
 
 Getting More Help

--- a/docs/userguide.rst
+++ b/docs/userguide.rst
@@ -13,14 +13,14 @@ Create a simple text label with default settings:
 
 .. code-block:: python
 
-   from ptouch import ConnectionNetwork, PTP900, TextLabel, LaminatedTape36mm
+   from ptouch import ConnectionNetwork, PTP900, TextLabel, Tape36mm
    from PIL import ImageFont
 
    connection = ConnectionNetwork("192.168.1.100")
    printer = PTP900(connection)
 
    font = ImageFont.load_default()
-   label = TextLabel("Hello World", LaminatedTape36mm, font=font)
+   label = TextLabel("Hello World", Tape36mm, font=font)
    printer.print(label)
 
 Custom Font and Size
@@ -36,10 +36,10 @@ Use TrueType fonts with custom sizes:
    font = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf", 48)
 
    # Auto-sizing is disabled when font has explicit size
-   label = TextLabel("Custom Font", LaminatedTape36mm, font=font, auto_size=False)
+   label = TextLabel("Custom Font", Tape36mm, font=font, auto_size=False)
 
    # Or let the library auto-size to 80% of tape height
-   label = TextLabel("Auto Sized", LaminatedTape36mm, font=font, auto_size=True)
+   label = TextLabel("Auto Sized", Tape36mm, font=font, auto_size=True)
 
 Text Alignment
 ~~~~~~~~~~~~~~
@@ -54,21 +54,21 @@ Control horizontal and vertical alignment:
 
    label = TextLabel(
        "Centered",
-       LaminatedTape36mm,
+       Tape36mm,
        font=font,
        align=TextLabel.Align.CENTER  # Center both ways
    )
 
    label = TextLabel(
        "Top Left",
-       LaminatedTape36mm,
+       Tape36mm,
        font=font,
        align=TextLabel.Align.LEFT | TextLabel.Align.TOP
    )
 
    label = TextLabel(
        "Bottom Right",
-       LaminatedTape36mm,
+       Tape36mm,
        font=font,
        align=TextLabel.Align.RIGHT | TextLabel.Align.BOTTOM
    )
@@ -83,7 +83,7 @@ Create labels with specific width:
    # Create 50mm wide label (useful for consistent sizing)
    label = TextLabel(
        "Short",
-       LaminatedTape36mm,
+       Tape36mm,
        font=font,
        width_mm=50.0
    )
@@ -99,13 +99,13 @@ Print images directly:
 .. code-block:: python
 
    from PIL import Image
-   from ptouch import Label, LaminatedTape36mm
+   from ptouch import Label, Tape36mm
 
    # Load image
    image = Image.open("logo.png")
 
    # Create label and print
-   label = Label(image, LaminatedTape36mm)
+   label = Label(image, Tape36mm)
    printer.print(label, margin_mm=3.0)
 
 Creating Custom Images
@@ -130,7 +130,7 @@ Generate labels programmatically:
    draw.rectangle([10, 10, 790, 444], outline="black", width=3)
 
    # Print
-   label = Label(img, LaminatedTape36mm)
+   label = Label(img, Tape36mm)
    printer.print(label)
 
 QR Code Labels
@@ -151,7 +151,7 @@ Create QR code labels:
    img = qr.make_image(fill_color="black", back_color="white")
 
    # Print
-   label = Label(img.convert("RGB"), LaminatedTape36mm)
+   label = Label(img.convert("RGB"), Tape36mm)
    printer.print(label)
 
 Multi-Label Printing
@@ -165,9 +165,9 @@ Save tape by using half-cuts between labels:
 .. code-block:: python
 
    labels = [
-       TextLabel("Server 1", LaminatedTape12mm, font=font),
-       TextLabel("Server 2", LaminatedTape12mm, font=font),
-       TextLabel("Server 3", LaminatedTape12mm, font=font),
+       TextLabel("Server 1", Tape12mm, font=font),
+       TextLabel("Server 2", Tape12mm, font=font),
+       TextLabel("Server 3", Tape12mm, font=font),
    ]
 
    # Half-cut between labels (default), full cut after last
@@ -191,7 +191,7 @@ Python:
 .. code-block:: python
 
    for i in range(5):
-       label = TextLabel(f"Asset {i:03d}", LaminatedTape12mm, font=font)
+       label = TextLabel(f"Asset {i:03d}", Tape12mm, font=font)
        printer.print(label)
 
 Connection Management

--- a/src/ptouch/__init__.py
+++ b/src/ptouch/__init__.py
@@ -17,10 +17,10 @@ Supported printers:
     - PT-P950NW (560 pins, 360 DPI)
 
 Example usage:
-    >>> from ptouch import PTP900W, ConnectionNetwork, LaminatedTape36mm, TextLabel
+    >>> from ptouch import PTP900W, ConnectionNetwork, Tape36mm, TextLabel
     >>> conn = ConnectionNetwork("192.168.1.100")
     >>> printer = PTP900W(conn)
-    >>> label = TextLabel("Hello, World!", LaminatedTape36mm)
+    >>> label = TextLabel("Hello, World!", Tape36mm)
     >>> printer.print(label)
 """
 
@@ -40,6 +40,7 @@ from .printer import LabelPrinter, MediaType, TapeConfig
 from .printers import PTE550W, PTP750W, PTP900, PTP900W, PTP910BT, PTP950NW
 from .tape import (
     HeatShrinkTape,
+    # Deprecated aliases (use Tape*mm instead)
     LaminatedTape,
     LaminatedTape3_5mm,
     LaminatedTape6mm,
@@ -49,6 +50,13 @@ from .tape import (
     LaminatedTape24mm,
     LaminatedTape36mm,
     Tape,
+    Tape3_5mm,
+    Tape6mm,
+    Tape9mm,
+    Tape12mm,
+    Tape18mm,
+    Tape24mm,
+    Tape36mm,
 )
 
 __version__ = "1.0.0"
@@ -81,6 +89,15 @@ __all__ = [
     "PTP950NW",
     # Tapes
     "Tape",
+    "Tape3_5mm",
+    "Tape6mm",
+    "Tape9mm",
+    "Tape12mm",
+    "Tape18mm",
+    "Tape24mm",
+    "Tape36mm",
+    "HeatShrinkTape",
+    # Deprecated tape aliases (use Tape*mm instead)
     "LaminatedTape",
     "LaminatedTape3_5mm",
     "LaminatedTape6mm",
@@ -89,7 +106,6 @@ __all__ = [
     "LaminatedTape18mm",
     "LaminatedTape24mm",
     "LaminatedTape36mm",
-    "HeatShrinkTape",
     # Labels
     "Label",
     "TextLabel",

--- a/src/ptouch/__main__.py
+++ b/src/ptouch/__main__.py
@@ -15,32 +15,32 @@ from . import (
     ConnectionNetwork,
     ConnectionUSB,
     Label,
-    LaminatedTape3_5mm,
-    LaminatedTape6mm,
-    LaminatedTape9mm,
-    LaminatedTape12mm,
-    LaminatedTape18mm,
-    LaminatedTape24mm,
-    LaminatedTape36mm,
     PTE550W,
     PTP750W,
     PTP900,
     PTP900W,
     PTP910BT,
     PTP950NW,
+    Tape3_5mm,
+    Tape6mm,
+    Tape9mm,
+    Tape12mm,
+    Tape18mm,
+    Tape24mm,
+    Tape36mm,
     TextLabel,
 )
 from .printer import LabelPrinter
 
 # Mapping of tape width (mm) to tape classes
 TAPE_WIDTHS = {
-    3.5: LaminatedTape3_5mm,
-    6: LaminatedTape6mm,
-    9: LaminatedTape9mm,
-    12: LaminatedTape12mm,
-    18: LaminatedTape18mm,
-    24: LaminatedTape24mm,
-    36: LaminatedTape36mm,
+    3.5: Tape3_5mm,
+    6: Tape6mm,
+    9: Tape9mm,
+    12: Tape12mm,
+    18: Tape18mm,
+    24: Tape24mm,
+    36: Tape36mm,
 }
 
 # Mapping of printer names to printer classes

--- a/src/ptouch/label.py
+++ b/src/ptouch/label.py
@@ -30,7 +30,7 @@ class Label:
         image : PIL.Image.Image
             The image to print.
         tape : type[Tape] | Tape
-            The tape class (e.g., LaminatedTape36mm) or instance.
+            The tape class (e.g., Tape36mm) or instance.
         """
         self.image = image
         self.tape = tape() if isinstance(tape, type) else tape
@@ -87,7 +87,7 @@ class TextLabel(Label):
         text : str
             Text to render.
         tape : type[Tape] | Tape
-            The tape class (e.g., LaminatedTape36mm) or instance.
+            The tape class (e.g., Tape36mm) or instance.
         font : str or ImageFont.FreeTypeFont
             Path to TrueType font file, or a pre-loaded ImageFont object.
         font_size : int or None, optional

--- a/src/ptouch/printers.py
+++ b/src/ptouch/printers.py
@@ -6,13 +6,13 @@
 
 from .printer import LabelPrinter, TapeConfig
 from .tape import (
-    LaminatedTape3_5mm,
-    LaminatedTape6mm,
-    LaminatedTape9mm,
-    LaminatedTape12mm,
-    LaminatedTape18mm,
-    LaminatedTape24mm,
-    LaminatedTape36mm,
+    Tape3_5mm,
+    Tape6mm,
+    Tape9mm,
+    Tape12mm,
+    Tape18mm,
+    Tape24mm,
+    Tape36mm,
 )
 
 
@@ -34,12 +34,12 @@ class PTE550W(LabelPrinter):
     # Pin configurations from official Brother PT-E550W specification document
     # Source: cv_pte550wp750wp710bt_eng_raster_102.pdf, page 20, section "2.3 Print Area"
     PIN_CONFIGS = {
-        LaminatedTape3_5mm: TapeConfig(left_pins=52, print_pins=24, right_pins=52),
-        LaminatedTape6mm: TapeConfig(left_pins=48, print_pins=32, right_pins=48),
-        LaminatedTape9mm: TapeConfig(left_pins=39, print_pins=50, right_pins=39),
-        LaminatedTape12mm: TapeConfig(left_pins=29, print_pins=70, right_pins=29),
-        LaminatedTape18mm: TapeConfig(left_pins=8, print_pins=112, right_pins=8),
-        LaminatedTape24mm: TapeConfig(left_pins=0, print_pins=128, right_pins=0),
+        Tape3_5mm: TapeConfig(left_pins=52, print_pins=24, right_pins=52),
+        Tape6mm: TapeConfig(left_pins=48, print_pins=32, right_pins=48),
+        Tape9mm: TapeConfig(left_pins=39, print_pins=50, right_pins=39),
+        Tape12mm: TapeConfig(left_pins=29, print_pins=70, right_pins=29),
+        Tape18mm: TapeConfig(left_pins=8, print_pins=112, right_pins=8),
+        Tape24mm: TapeConfig(left_pins=0, print_pins=128, right_pins=0),
     }
 
 
@@ -68,13 +68,13 @@ class PTP900Series(LabelPrinter):
     # Pin configurations from official Brother PT-P900 specification document
     # Source: cv_ptp900_eng_raster_102.pdf, pages 23-24, section 2.3.5 "Raster line"
     PIN_CONFIGS = {
-        LaminatedTape3_5mm: TapeConfig(left_pins=248, print_pins=48, right_pins=264),
-        LaminatedTape6mm: TapeConfig(left_pins=240, print_pins=64, right_pins=256),
-        LaminatedTape9mm: TapeConfig(left_pins=219, print_pins=106, right_pins=235),
-        LaminatedTape12mm: TapeConfig(left_pins=197, print_pins=150, right_pins=213),
-        LaminatedTape18mm: TapeConfig(left_pins=155, print_pins=234, right_pins=171),
-        LaminatedTape24mm: TapeConfig(left_pins=112, print_pins=320, right_pins=128),
-        LaminatedTape36mm: TapeConfig(left_pins=45, print_pins=454, right_pins=61),
+        Tape3_5mm: TapeConfig(left_pins=248, print_pins=48, right_pins=264),
+        Tape6mm: TapeConfig(left_pins=240, print_pins=64, right_pins=256),
+        Tape9mm: TapeConfig(left_pins=219, print_pins=106, right_pins=235),
+        Tape12mm: TapeConfig(left_pins=197, print_pins=150, right_pins=213),
+        Tape18mm: TapeConfig(left_pins=155, print_pins=234, right_pins=171),
+        Tape24mm: TapeConfig(left_pins=112, print_pins=320, right_pins=128),
+        Tape36mm: TapeConfig(left_pins=45, print_pins=454, right_pins=61),
     }
 
 

--- a/src/ptouch/tape.py
+++ b/src/ptouch/tape.py
@@ -4,6 +4,7 @@
 
 """Tape types for Brother P-touch label printers."""
 
+import warnings
 from abc import ABC
 
 
@@ -21,18 +22,8 @@ class Tape(ABC):
     width_mm: int
 
 
-class LaminatedTape(Tape):
-    """Base class for laminated tapes (TZe series).
-
-    Laminated tapes have a protective layer over the printed content,
-    making them durable and resistant to fading, water, and abrasion.
-    """
-
-    pass
-
-
-class LaminatedTape3_5mm(LaminatedTape):
-    """3.5mm laminated tape.
+class Tape3_5mm(Tape):
+    """3.5mm tape.
 
     Note: Media size reported by printer is 4mm.
     """
@@ -40,38 +31,38 @@ class LaminatedTape3_5mm(LaminatedTape):
     width_mm = 4
 
 
-class LaminatedTape6mm(LaminatedTape):
-    """6mm laminated tape."""
+class Tape6mm(Tape):
+    """6mm tape."""
 
     width_mm = 6
 
 
-class LaminatedTape9mm(LaminatedTape):
-    """9mm laminated tape."""
+class Tape9mm(Tape):
+    """9mm tape."""
 
     width_mm = 9
 
 
-class LaminatedTape12mm(LaminatedTape):
-    """12mm laminated tape."""
+class Tape12mm(Tape):
+    """12mm tape."""
 
     width_mm = 12
 
 
-class LaminatedTape18mm(LaminatedTape):
-    """18mm laminated tape."""
+class Tape18mm(Tape):
+    """18mm tape."""
 
     width_mm = 18
 
 
-class LaminatedTape24mm(LaminatedTape):
-    """24mm laminated tape."""
+class Tape24mm(Tape):
+    """24mm tape."""
 
     width_mm = 24
 
 
-class LaminatedTape36mm(LaminatedTape):
-    """36mm laminated tape."""
+class Tape36mm(Tape):
+    """36mm tape."""
 
     width_mm = 36
 
@@ -84,3 +75,53 @@ class HeatShrinkTape(Tape):
     """
 
     pass
+
+
+# =============================================================================
+# Deprecated aliases for backward compatibility
+# =============================================================================
+
+
+def _deprecated_alias(new_class: type, old_name: str) -> type:
+    """Create a deprecated alias class that warns on instantiation."""
+
+    class DeprecatedTape(new_class):
+        def __init__(self) -> None:
+            warnings.warn(
+                f"{old_name} is deprecated, use {new_class.__name__} instead",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            super().__init__()
+
+    DeprecatedTape.__name__ = old_name
+    DeprecatedTape.__qualname__ = old_name
+    DeprecatedTape.__doc__ = f"Deprecated: Use {new_class.__name__} instead."
+    return DeprecatedTape
+
+
+# Deprecated base class alias
+class LaminatedTape(Tape):
+    """Deprecated: Use Tape instead.
+
+    .. deprecated::
+        The LaminatedTape class is deprecated. Use Tape directly.
+    """
+
+    def __init__(self) -> None:
+        warnings.warn(
+            "LaminatedTape is deprecated, use Tape instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__()
+
+
+# Deprecated tape size aliases
+LaminatedTape3_5mm = _deprecated_alias(Tape3_5mm, "LaminatedTape3_5mm")
+LaminatedTape6mm = _deprecated_alias(Tape6mm, "LaminatedTape6mm")
+LaminatedTape9mm = _deprecated_alias(Tape9mm, "LaminatedTape9mm")
+LaminatedTape12mm = _deprecated_alias(Tape12mm, "LaminatedTape12mm")
+LaminatedTape18mm = _deprecated_alias(Tape18mm, "LaminatedTape18mm")
+LaminatedTape24mm = _deprecated_alias(Tape24mm, "LaminatedTape24mm")
+LaminatedTape36mm = _deprecated_alias(Tape36mm, "LaminatedTape36mm")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,10 +8,10 @@ import pytest
 from PIL import Image
 
 from ptouch import (
-    LaminatedTape6mm,
-    LaminatedTape12mm,
-    LaminatedTape24mm,
-    LaminatedTape36mm,
+    Tape6mm,
+    Tape12mm,
+    Tape24mm,
+    Tape36mm,
 )
 from ptouch.connection import Connection
 
@@ -63,24 +63,24 @@ def sample_image_with_content() -> Image.Image:
 
 
 @pytest.fixture
-def tape_6mm() -> LaminatedTape6mm:
-    """Provide a 6mm laminated tape instance."""
-    return LaminatedTape6mm()
+def tape_6mm() -> Tape6mm:
+    """Provide a 6mm tape instance."""
+    return Tape6mm()
 
 
 @pytest.fixture
-def tape_12mm() -> LaminatedTape12mm:
-    """Provide a 12mm laminated tape instance."""
-    return LaminatedTape12mm()
+def tape_12mm() -> Tape12mm:
+    """Provide a 12mm tape instance."""
+    return Tape12mm()
 
 
 @pytest.fixture
-def tape_24mm() -> LaminatedTape24mm:
-    """Provide a 24mm laminated tape instance."""
-    return LaminatedTape24mm()
+def tape_24mm() -> Tape24mm:
+    """Provide a 24mm tape instance."""
+    return Tape24mm()
 
 
 @pytest.fixture
-def tape_36mm() -> LaminatedTape36mm:
-    """Provide a 36mm laminated tape instance."""
-    return LaminatedTape36mm()
+def tape_36mm() -> Tape36mm:
+    """Provide a 36mm tape instance."""
+    return Tape36mm()

--- a/tests/test_label.py
+++ b/tests/test_label.py
@@ -8,7 +8,7 @@ import pytest
 from PIL import Image, ImageFont
 
 from ptouch.label import Align, Label, TextLabel
-from ptouch.tape import LaminatedTape12mm, LaminatedTape36mm
+from ptouch.tape import Tape12mm, Tape36mm
 
 
 class TestAlign:
@@ -64,14 +64,14 @@ class TestLabel:
 
     def test_label_with_tape_class(self, sample_image: Image.Image) -> None:
         """Test Label initialization with tape class."""
-        label = Label(sample_image, LaminatedTape36mm)
+        label = Label(sample_image, Tape36mm)
         assert label.image is sample_image
-        assert isinstance(label.tape, LaminatedTape36mm)
+        assert isinstance(label.tape, Tape36mm)
         assert label.tape.width_mm == 36
 
     def test_label_with_tape_instance(self, sample_image: Image.Image) -> None:
         """Test Label initialization with tape instance."""
-        tape = LaminatedTape12mm()
+        tape = Tape12mm()
         label = Label(sample_image, tape)
         assert label.image is sample_image
         assert label.tape is tape
@@ -79,7 +79,7 @@ class TestLabel:
 
     def test_label_prepare_is_noop(self, sample_image: Image.Image) -> None:
         """Test that Label.prepare() does nothing (base implementation)."""
-        label = Label(sample_image, LaminatedTape36mm)
+        label = Label(sample_image, Tape36mm)
         # Should not raise
         label.prepare(100)
         # Image should be unchanged
@@ -109,40 +109,40 @@ class TestTextLabel:
 
     def test_text_label_initialization_with_tape_class(self, font_path: str) -> None:
         """Test TextLabel initialization with tape class."""
-        label = TextLabel("Hello", LaminatedTape36mm, font_path)
+        label = TextLabel("Hello", Tape36mm, font_path)
         assert label.text == "Hello"
-        assert isinstance(label.tape, LaminatedTape36mm)
+        assert isinstance(label.tape, Tape36mm)
         assert label.font == font_path
         assert label.font_size is None
         assert label.align == TextLabel.Align.CENTER
 
     def test_text_label_initialization_with_tape_instance(self, font_path: str) -> None:
         """Test TextLabel initialization with tape instance."""
-        tape = LaminatedTape12mm()
+        tape = Tape12mm()
         label = TextLabel("World", tape, font_path)
         assert label.text == "World"
         assert label.tape is tape
 
     def test_text_label_initialization_with_custom_font_size(self, font_path: str) -> None:
         """Test TextLabel initialization with custom font size."""
-        label = TextLabel("Test", LaminatedTape36mm, font_path, font_size=48)
+        label = TextLabel("Test", Tape36mm, font_path, font_size=48)
         assert label.font_size == 48
 
     def test_text_label_initialization_with_custom_align(self, font_path: str) -> None:
         """Test TextLabel initialization with custom alignment."""
         align = TextLabel.Align.LEFT | TextLabel.Align.TOP
-        label = TextLabel("Test", LaminatedTape36mm, font_path, align=align)
+        label = TextLabel("Test", Tape36mm, font_path, align=align)
         assert label.align == align
 
     def test_text_label_image_raises_before_prepare(self, font_path: str) -> None:
         """Test that accessing image before prepare() raises RuntimeError."""
-        label = TextLabel("Hello", LaminatedTape36mm, font_path)
+        label = TextLabel("Hello", Tape36mm, font_path)
         with pytest.raises(RuntimeError, match="not been rendered yet"):
             _ = label.image
 
     def test_text_label_prepare_renders_image(self, font_path: str) -> None:
         """Test that prepare() renders the text to an image."""
-        label = TextLabel("Hello", LaminatedTape36mm, font_path)
+        label = TextLabel("Hello", Tape36mm, font_path)
         label.prepare(height=100)
         img = label.image
         assert isinstance(img, Image.Image)
@@ -151,7 +151,7 @@ class TestTextLabel:
 
     def test_text_label_prepare_uses_default_font_size(self, font_path: str) -> None:
         """Test that prepare() uses 80% of height as default font size."""
-        label = TextLabel("Test", LaminatedTape36mm, font_path)
+        label = TextLabel("Test", Tape36mm, font_path)
         label.prepare(height=100)
         # Font size should be 80 (80% of 100)
         # We can't directly check font size, but the image should be rendered
@@ -159,7 +159,7 @@ class TestTextLabel:
 
     def test_text_label_prepare_is_idempotent(self, font_path: str) -> None:
         """Test that calling prepare() multiple times doesn't re-render."""
-        label = TextLabel("Hello", LaminatedTape36mm, font_path)
+        label = TextLabel("Hello", Tape36mm, font_path)
         label.prepare(height=100)
         img1 = label.image
         label.prepare(height=200)  # Different height, but should not re-render
@@ -168,7 +168,7 @@ class TestTextLabel:
 
     def test_text_label_image_is_rgb(self, font_path: str) -> None:
         """Test that rendered image is RGB mode."""
-        label = TextLabel("Hello", LaminatedTape36mm, font_path)
+        label = TextLabel("Hello", Tape36mm, font_path)
         label.prepare(height=100)
         assert label.image.mode == "RGB"
 
@@ -183,21 +183,21 @@ class TestTextLabel:
             Align.LEFT | Align.VCENTER,
         ]
         for align in alignments:
-            label = TextLabel("Test", LaminatedTape36mm, font_path, align=align)
+            label = TextLabel("Test", Tape36mm, font_path, align=align)
             label.prepare(height=100)
             assert isinstance(label.image, Image.Image)
 
     def test_text_label_with_imagefont(self, font_path: str) -> None:
         """Test TextLabel initialization with ImageFont object."""
         font = ImageFont.truetype(font_path, size=24)
-        label = TextLabel("Hello", LaminatedTape36mm, font)
+        label = TextLabel("Hello", Tape36mm, font)
         assert label.font is font
         label.prepare(height=100)
         assert isinstance(label.image, Image.Image)
 
     def test_text_label_with_min_width_mm(self, font_path: str) -> None:
         """Test TextLabel with min_width_mm parameter."""
-        label = TextLabel("X", LaminatedTape36mm, font_path, min_width_mm=50.0)
+        label = TextLabel("X", Tape36mm, font_path, min_width_mm=50.0)
         assert label.min_width_mm == 50.0
         label.prepare(height=100, resolution_dpi=180)
         # 50mm at 180 DPI = 50 * 180 / 25.4 ≈ 354 pixels minimum
@@ -206,18 +206,18 @@ class TestTextLabel:
     def test_text_label_invalid_font_type_raises_valueerror(self) -> None:
         """Test that invalid font type raises ValueError."""
         with pytest.raises(ValueError, match="font must be a path string or ImageFont"):
-            TextLabel("Hello", LaminatedTape36mm, 123)  # type: ignore[arg-type]
+            TextLabel("Hello", Tape36mm, 123)  # type: ignore[arg-type]
 
     def test_text_label_auto_size_true_scales_font(self, font_path: str) -> None:
         """Test that auto_size=True scales font to 80% of height."""
-        label = TextLabel("Hello", LaminatedTape36mm, font_path, auto_size=True)
+        label = TextLabel("Hello", Tape36mm, font_path, auto_size=True)
         label.prepare(height=100)
         # Font should be auto-sized, image should be rendered
         assert isinstance(label.image, Image.Image)
 
     def test_text_label_auto_size_false_uses_font_size(self, font_path: str) -> None:
         """Test that auto_size=False uses explicit font_size."""
-        label = TextLabel("Hello", LaminatedTape36mm, font_path, font_size=24, auto_size=False)
+        label = TextLabel("Hello", Tape36mm, font_path, font_size=24, auto_size=False)
         assert label.auto_size is False
         assert label.font_size == 24
         label.prepare(height=100)
@@ -226,7 +226,7 @@ class TestTextLabel:
     def test_text_label_auto_size_false_with_imagefont(self, font_path: str) -> None:
         """Test that auto_size=False uses ImageFont's built-in size."""
         font = ImageFont.truetype(font_path, size=24)
-        label = TextLabel("Hello", LaminatedTape36mm, font, auto_size=False)
+        label = TextLabel("Hello", Tape36mm, font, auto_size=False)
         assert label.auto_size is False
         label.prepare(height=100)
         assert isinstance(label.image, Image.Image)

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -12,11 +12,11 @@ from ptouch.printer import TapeConfig
 from ptouch.printer import MediaType
 from ptouch.printers import PTE550W, PTP750W, PTP900
 from ptouch.tape import (
-    LaminatedTape3_5mm,
-    LaminatedTape6mm,
-    LaminatedTape12mm,
-    LaminatedTape24mm,
-    LaminatedTape36mm,
+    Tape3_5mm,
+    Tape6mm,
+    Tape12mm,
+    Tape24mm,
+    Tape36mm,
 )
 
 from .conftest import MockConnection
@@ -65,17 +65,17 @@ class TestPTE550W:
 
     def test_pin_configs(self) -> None:
         """Test that PIN_CONFIGS contains expected tape types."""
-        assert LaminatedTape3_5mm in PTE550W.PIN_CONFIGS
-        assert LaminatedTape6mm in PTE550W.PIN_CONFIGS
-        assert LaminatedTape12mm in PTE550W.PIN_CONFIGS
-        assert LaminatedTape24mm in PTE550W.PIN_CONFIGS
+        assert Tape3_5mm in PTE550W.PIN_CONFIGS
+        assert Tape6mm in PTE550W.PIN_CONFIGS
+        assert Tape12mm in PTE550W.PIN_CONFIGS
+        assert Tape24mm in PTE550W.PIN_CONFIGS
         # E550W doesn't support 36mm
-        assert LaminatedTape36mm not in PTE550W.PIN_CONFIGS
+        assert Tape36mm not in PTE550W.PIN_CONFIGS
 
     def test_get_tape_config(self, mock_connection: MockConnection) -> None:
         """Test getting tape configuration."""
         printer = PTE550W(mock_connection)
-        tape = LaminatedTape12mm()
+        tape = Tape12mm()
         config = printer.get_tape_config(tape)
         assert isinstance(config, TapeConfig)
         assert config.left_pins == 29
@@ -87,7 +87,7 @@ class TestPTE550W:
     def test_get_tape_config_unsupported_tape(self, mock_connection: MockConnection) -> None:
         """Test that unsupported tape raises ValueError."""
         printer = PTE550W(mock_connection)
-        tape = LaminatedTape36mm()
+        tape = Tape36mm()
         with pytest.raises(ValueError, match="not supported"):
             printer.get_tape_config(tape)
 
@@ -118,13 +118,13 @@ class TestPTP900:
 
     def test_supports_36mm_tape(self) -> None:
         """Test that P900 supports 36mm tape."""
-        assert LaminatedTape3_5mm in PTP900.PIN_CONFIGS
-        assert LaminatedTape36mm in PTP900.PIN_CONFIGS
+        assert Tape3_5mm in PTP900.PIN_CONFIGS
+        assert Tape36mm in PTP900.PIN_CONFIGS
 
     def test_get_tape_config_36mm(self, mock_connection: MockConnection) -> None:
         """Test getting 36mm tape configuration."""
         printer = PTP900(mock_connection)
-        tape = LaminatedTape36mm()
+        tape = Tape36mm()
         config = printer.get_tape_config(tape)
         assert config.left_pins == 45
         assert config.print_pins == 454
@@ -219,7 +219,7 @@ class TestLabelPrinterPrint:
     ) -> None:
         """Test that print sends data to the connection."""
         printer = PTE550W(mock_connection, use_compression=True)
-        label = Label(sample_image_with_content, LaminatedTape12mm)
+        label = Label(sample_image_with_content, Tape12mm)
         printer.print(label)
         # Should have sent data
         assert len(mock_connection.data) > 0
@@ -231,7 +231,7 @@ class TestLabelPrinterPrint:
     ) -> None:
         """Test print with custom margin."""
         printer = PTE550W(mock_connection)
-        label = Label(sample_image, LaminatedTape12mm)
+        label = Label(sample_image, Tape12mm)
         printer.print(label, margin_mm=5.0)
         assert len(mock_connection.data) > 0
 
@@ -240,7 +240,7 @@ class TestLabelPrinterPrint:
     ) -> None:
         """Test that margin below minimum raises ValueError."""
         printer = PTE550W(mock_connection)
-        label = Label(sample_image, LaminatedTape12mm)
+        label = Label(sample_image, Tape12mm)
         with pytest.raises(ValueError, match="Margin must be between"):
             printer.print(label, margin_mm=0.5)
 
@@ -249,7 +249,7 @@ class TestLabelPrinterPrint:
     ) -> None:
         """Test that margin above maximum raises ValueError."""
         printer = PTE550W(mock_connection)
-        label = Label(sample_image, LaminatedTape12mm)
+        label = Label(sample_image, Tape12mm)
         with pytest.raises(ValueError, match="Margin must be between"):
             printer.print(label, margin_mm=200.0)
 
@@ -258,7 +258,7 @@ class TestLabelPrinterPrint:
     ) -> None:
         """Test that printing with unsupported tape raises ValueError."""
         printer = PTE550W(mock_connection)
-        label = Label(sample_image, LaminatedTape36mm)  # E550W doesn't support 36mm
+        label = Label(sample_image, Tape36mm)  # E550W doesn't support 36mm
         with pytest.raises(ValueError, match="not supported"):
             printer.print(label)
 
@@ -267,7 +267,7 @@ class TestLabelPrinterPrint:
     ) -> None:
         """Test printing in high resolution mode."""
         printer = PTE550W(mock_connection)
-        label = Label(sample_image, LaminatedTape12mm)
+        label = Label(sample_image, Tape12mm)
         printer.print(label, high_resolution=True)
         assert len(mock_connection.data) > 0
 
@@ -276,7 +276,7 @@ class TestLabelPrinterPrint:
     ) -> None:
         """Test that print data ends with print command (0x1a) and initialize."""
         printer = PTE550W(mock_connection, use_compression=True)
-        label = Label(sample_image, LaminatedTape12mm)
+        label = Label(sample_image, Tape12mm)
         printer.print(label)
         # Should contain print command
         assert b"\x1a" in mock_connection.data
@@ -289,7 +289,7 @@ class TestImagePreparation:
         """Test that _prepare_image returns a 1-bit image."""
         printer = PTE550W(mock_connection)
         img = Image.new("RGB", (100, 50), color=(255, 255, 255))
-        tape = LaminatedTape12mm()
+        tape = Tape12mm()
         config = printer.get_tape_config(tape)
         img_1bit = printer._prepare_image(img, config)
         assert img_1bit.mode == "1"
@@ -298,7 +298,7 @@ class TestImagePreparation:
         """Test that prepared image height matches print_pins."""
         printer = PTE550W(mock_connection)
         img = Image.new("RGB", (100, 50), color=(255, 255, 255))
-        tape = LaminatedTape12mm()
+        tape = Tape12mm()
         config = printer.get_tape_config(tape)
         img_1bit = printer._prepare_image(img, config)
         assert img_1bit.height == config.print_pins
@@ -307,7 +307,7 @@ class TestImagePreparation:
         """Test that raster data has correct length."""
         printer = PTE550W(mock_connection)
         img = Image.new("RGB", (100, 50), color=(255, 255, 255))
-        tape = LaminatedTape12mm()
+        tape = Tape12mm()
         config = printer.get_tape_config(tape)
         img_1bit = printer._prepare_image(img, config)
         raster = printer._generate_raster(img_1bit, config)
@@ -325,8 +325,8 @@ class TestLabelPrinterPrintMulti:
         """Test that print_multi sends data to the connection."""
         printer = PTE550W(mock_connection, use_compression=True)
         labels = [
-            Label(sample_image, LaminatedTape12mm),
-            Label(sample_image, LaminatedTape12mm),
+            Label(sample_image, Tape12mm),
+            Label(sample_image, Tape12mm),
         ]
         printer.print_multi(labels)
         # Should have sent data
@@ -339,7 +339,7 @@ class TestLabelPrinterPrintMulti:
     ) -> None:
         """Test that print_multi with a single label works correctly."""
         printer = PTE550W(mock_connection, use_compression=True)
-        labels = [Label(sample_image, LaminatedTape12mm)]
+        labels = [Label(sample_image, Tape12mm)]
         printer.print_multi(labels)
         # Should have sent data
         assert len(mock_connection.data) > 0
@@ -358,8 +358,8 @@ class TestLabelPrinterPrintMulti:
         """Test that print_multi with different tape types raises ValueError."""
         printer = PTE550W(mock_connection)
         labels = [
-            Label(sample_image, LaminatedTape12mm),
-            Label(sample_image, LaminatedTape6mm),
+            Label(sample_image, Tape12mm),
+            Label(sample_image, Tape6mm),
         ]
         with pytest.raises(ValueError, match="same tape type"):
             printer.print_multi(labels)
@@ -370,8 +370,8 @@ class TestLabelPrinterPrintMulti:
         """Test that multi-label print has form feed (0x0C) between labels."""
         printer = PTE550W(mock_connection, use_compression=True)
         labels = [
-            Label(sample_image, LaminatedTape12mm),
-            Label(sample_image, LaminatedTape12mm),
+            Label(sample_image, Tape12mm),
+            Label(sample_image, Tape12mm),
         ]
         printer.print_multi(labels)
         # Form feed (0x0C) should appear between labels (not at end)
@@ -383,8 +383,8 @@ class TestLabelPrinterPrintMulti:
         """Test that multi-label print ends with print command (0x1a)."""
         printer = PTE550W(mock_connection, use_compression=True)
         labels = [
-            Label(sample_image, LaminatedTape12mm),
-            Label(sample_image, LaminatedTape12mm),
+            Label(sample_image, Tape12mm),
+            Label(sample_image, Tape12mm),
         ]
         printer.print_multi(labels)
         # Should contain final print command
@@ -396,8 +396,8 @@ class TestLabelPrinterPrintMulti:
         """Test that printing with unsupported tape raises ValueError."""
         printer = PTE550W(mock_connection)
         labels = [
-            Label(sample_image, LaminatedTape36mm),  # E550W doesn't support 36mm
-            Label(sample_image, LaminatedTape36mm),
+            Label(sample_image, Tape36mm),  # E550W doesn't support 36mm
+            Label(sample_image, Tape36mm),
         ]
         with pytest.raises(ValueError, match="not supported"):
             printer.print_multi(labels)
@@ -408,8 +408,8 @@ class TestLabelPrinterPrintMulti:
         """Test print_multi with custom margin."""
         printer = PTE550W(mock_connection)
         labels = [
-            Label(sample_image, LaminatedTape12mm),
-            Label(sample_image, LaminatedTape12mm),
+            Label(sample_image, Tape12mm),
+            Label(sample_image, Tape12mm),
         ]
         printer.print_multi(labels, margin_mm=5.0)
         assert len(mock_connection.data) > 0
@@ -420,8 +420,8 @@ class TestLabelPrinterPrintMulti:
         """Test print_multi in high resolution mode."""
         printer = PTE550W(mock_connection)
         labels = [
-            Label(sample_image, LaminatedTape12mm),
-            Label(sample_image, LaminatedTape12mm),
+            Label(sample_image, Tape12mm),
+            Label(sample_image, Tape12mm),
         ]
         printer.print_multi(labels, high_resolution=True)
         assert len(mock_connection.data) > 0

--- a/tests/test_tape.py
+++ b/tests/test_tape.py
@@ -17,6 +17,13 @@ from ptouch.tape import (
     LaminatedTape24mm,
     LaminatedTape36mm,
     Tape,
+    Tape3_5mm,
+    Tape6mm,
+    Tape9mm,
+    Tape12mm,
+    Tape18mm,
+    Tape24mm,
+    Tape36mm,
 )
 
 
@@ -26,47 +33,39 @@ class TestTapeWidths:
     @pytest.mark.parametrize(
         "tape_class,expected_width",
         [
-            (LaminatedTape3_5mm, 4),
-            (LaminatedTape6mm, 6),
-            (LaminatedTape9mm, 9),
-            (LaminatedTape12mm, 12),
-            (LaminatedTape18mm, 18),
-            (LaminatedTape24mm, 24),
-            (LaminatedTape36mm, 36),
+            (Tape3_5mm, 4),
+            (Tape6mm, 6),
+            (Tape9mm, 9),
+            (Tape12mm, 12),
+            (Tape18mm, 18),
+            (Tape24mm, 24),
+            (Tape36mm, 36),
         ],
     )
-    def test_laminated_tape_width(
-        self, tape_class: type[LaminatedTape], expected_width: int
-    ) -> None:
-        """Test that laminated tape classes have correct width_mm."""
+    def test_tape_width(self, tape_class: type[Tape], expected_width: int) -> None:
+        """Test that tape classes have correct width_mm."""
         tape = tape_class()
         assert tape.width_mm == expected_width
 
     @pytest.mark.parametrize(
         "tape_class,expected_width",
         [
-            (LaminatedTape3_5mm, 4),
-            (LaminatedTape6mm, 6),
-            (LaminatedTape9mm, 9),
-            (LaminatedTape12mm, 12),
-            (LaminatedTape18mm, 18),
-            (LaminatedTape24mm, 24),
-            (LaminatedTape36mm, 36),
+            (Tape3_5mm, 4),
+            (Tape6mm, 6),
+            (Tape9mm, 9),
+            (Tape12mm, 12),
+            (Tape18mm, 18),
+            (Tape24mm, 24),
+            (Tape36mm, 36),
         ],
     )
-    def test_tape_width_class_attribute(
-        self, tape_class: type[LaminatedTape], expected_width: int
-    ) -> None:
+    def test_tape_width_class_attribute(self, tape_class: type[Tape], expected_width: int) -> None:
         """Test that width_mm is accessible as class attribute."""
         assert tape_class.width_mm == expected_width
 
 
 class TestTapeInheritance:
     """Test tape class inheritance."""
-
-    def test_laminated_tape_inherits_from_tape(self) -> None:
-        """Test that LaminatedTape inherits from Tape."""
-        assert issubclass(LaminatedTape, Tape)
 
     def test_heat_shrink_tape_inherits_from_tape(self) -> None:
         """Test that HeatShrinkTape inherits from Tape."""
@@ -75,20 +74,17 @@ class TestTapeInheritance:
     @pytest.mark.parametrize(
         "tape_class",
         [
-            LaminatedTape3_5mm,
-            LaminatedTape6mm,
-            LaminatedTape9mm,
-            LaminatedTape12mm,
-            LaminatedTape18mm,
-            LaminatedTape24mm,
-            LaminatedTape36mm,
+            Tape3_5mm,
+            Tape6mm,
+            Tape9mm,
+            Tape12mm,
+            Tape18mm,
+            Tape24mm,
+            Tape36mm,
         ],
     )
-    def test_laminated_tape_sizes_inherit_from_laminated_tape(
-        self, tape_class: type[LaminatedTape]
-    ) -> None:
-        """Test that all laminated tape sizes inherit from LaminatedTape."""
-        assert issubclass(tape_class, LaminatedTape)
+    def test_tape_sizes_inherit_from_tape(self, tape_class: type[Tape]) -> None:
+        """Test that all tape sizes inherit from Tape."""
         assert issubclass(tape_class, Tape)
 
 
@@ -98,18 +94,67 @@ class TestTapeInstantiation:
     @pytest.mark.parametrize(
         "tape_class",
         [
-            LaminatedTape3_5mm,
-            LaminatedTape6mm,
-            LaminatedTape9mm,
-            LaminatedTape12mm,
-            LaminatedTape18mm,
-            LaminatedTape24mm,
-            LaminatedTape36mm,
+            Tape3_5mm,
+            Tape6mm,
+            Tape9mm,
+            Tape12mm,
+            Tape18mm,
+            Tape24mm,
+            Tape36mm,
         ],
     )
-    def test_laminated_tape_can_be_instantiated(self, tape_class: type[LaminatedTape]) -> None:
-        """Test that laminated tape classes can be instantiated."""
+    def test_tape_can_be_instantiated(self, tape_class: type[Tape]) -> None:
+        """Test that tape classes can be instantiated."""
         tape = tape_class()
         assert isinstance(tape, tape_class)
-        assert isinstance(tape, LaminatedTape)
         assert isinstance(tape, Tape)
+
+
+class TestDeprecatedAliases:
+    """Test deprecated LaminatedTape* aliases."""
+
+    @pytest.mark.parametrize(
+        "deprecated_class,new_class,expected_width",
+        [
+            (LaminatedTape3_5mm, Tape3_5mm, 4),
+            (LaminatedTape6mm, Tape6mm, 6),
+            (LaminatedTape9mm, Tape9mm, 9),
+            (LaminatedTape12mm, Tape12mm, 12),
+            (LaminatedTape18mm, Tape18mm, 18),
+            (LaminatedTape24mm, Tape24mm, 24),
+            (LaminatedTape36mm, Tape36mm, 36),
+        ],
+    )
+    def test_deprecated_alias_emits_warning(
+        self, deprecated_class: type, new_class: type, expected_width: int
+    ) -> None:
+        """Test that deprecated aliases emit DeprecationWarning."""
+        with pytest.warns(DeprecationWarning, match="deprecated"):
+            tape = deprecated_class()
+        assert tape.width_mm == expected_width
+        assert isinstance(tape, new_class)
+        assert isinstance(tape, Tape)
+
+    def test_laminated_tape_base_emits_warning(self) -> None:
+        """Test that LaminatedTape base class emits DeprecationWarning."""
+        with pytest.warns(DeprecationWarning, match="LaminatedTape is deprecated"):
+            LaminatedTape()
+
+    @pytest.mark.parametrize(
+        "deprecated_class,new_class",
+        [
+            (LaminatedTape3_5mm, Tape3_5mm),
+            (LaminatedTape6mm, Tape6mm),
+            (LaminatedTape9mm, Tape9mm),
+            (LaminatedTape12mm, Tape12mm),
+            (LaminatedTape18mm, Tape18mm),
+            (LaminatedTape24mm, Tape24mm),
+            (LaminatedTape36mm, Tape36mm),
+        ],
+    )
+    def test_deprecated_alias_is_subclass_of_new_class(
+        self, deprecated_class: type, new_class: type
+    ) -> None:
+        """Test that deprecated aliases are subclasses of their new counterparts."""
+        assert issubclass(deprecated_class, new_class)
+        assert issubclass(deprecated_class, Tape)


### PR DESCRIPTION
- Add LaminatedTape3_5mm class with width_mm = 4 (per Brother manual media size)
- Add PIN_CONFIGS for 3.5mm tape in PTE550W (left=52, print=24, right=52)
- Add PIN_CONFIGS for 3.5mm tape in PTP900Series (left=248, print=48, right=264)
- Update tests to include 3.5mm tape in all parametrized tests
- Update README with 3.5mm in supported tape widths list