### PR TITLE
Add Read the Docs documentation setup

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,19 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.13"
+
+sphinx:
+  configuration: docs/conf.py
+
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,53 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath('../src'))
+
+project = 'ptouch'
+copyright = '2024-2026, Nicolai Buchwitz'
+author = 'Nicolai Buchwitz'
+release = '1.0'
+
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.napoleon',
+    'sphinx.ext.viewcode',
+    'sphinx.ext.intersphinx',
+    'sphinx_autodoc_typehints',
+]
+
+templates_path = ['_templates']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+html_theme = 'sphinx_rtd_theme'
+html_static_path = ['_static']
+
+# Napoleon settings (for NumPy-style docstrings)
+napoleon_google_docstring = False
+napoleon_numpy_docstring = True
+napoleon_include_init_with_doc = True
+napoleon_include_private_with_doc = False
+napoleon_include_special_with_doc = True
+napoleon_use_admonition_for_examples = True
+napoleon_use_admonition_for_notes = True
+napoleon_use_admonition_for_references = False
+napoleon_use_ivar = False
+napoleon_use_param = True
+napoleon_use_rtype = True
+napoleon_preprocess_types = True
+napoleon_type_aliases = None
+napoleon_attr_annotations = True
+
+# Intersphinx mapping
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3', None),
+    'pillow': ('https://pillow.readthedocs.io/en/stable/', None),
+}
+
+# Autodoc settings
+autodoc_default_options = {
+    'members': True,
+    'member-order': 'bysource',
+    'special-members': '__init__',
+    'undoc-members': True,
+    'exclude-members': '__weakref__'
+}

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,87 @@
+ptouch - Brother P-touch Label Printer Library
+===============================================
+
+A Python library for Brother P-touch label printers with support for USB and network connections.
+
+Features
+--------
+
+* Support for multiple Brother P-touch models (PT-E550W, PT-P750W, PT-P900 series)
+* Network (TCP/IP) and USB connections
+* Text labels with customizable fonts and alignment
+* Image label printing
+* Multi-label printing with half-cut support
+* High resolution mode support
+* TIFF compression for efficient data transfer
+* Comprehensive error handling with specific exception types
+
+Quick Start
+-----------
+
+.. code-block:: python
+
+   from ptouch import ConnectionNetwork, PTP900, TextLabel, LaminatedTape36mm
+   
+   connection = ConnectionNetwork("192.168.1.100")
+   printer = PTP900(connection, high_resolution=True)
+   
+   label = TextLabel("Hello World", LaminatedTape36mm, 
+                     font="/path/to/font.ttf")
+   printer.print(label)
+
+API Reference
+-------------
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   api/connection
+   api/printer
+   api/label
+   api/tape
+   api/exceptions
+
+Connection Module
+-----------------
+
+.. automodule:: ptouch.connection
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Printer Module
+--------------
+
+.. automodule:: ptouch.printer
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: ptouch.printers
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Label Module
+------------
+
+.. automodule:: ptouch.label
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Tape Module
+-----------
+
+.. automodule:: ptouch.tape
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,10 +26,20 @@ dependencies = [
 ]
 requires-python = ">= 3.11"
 
+[project.urls]
+Documentation = "https://ptouch.readthedocs.io/"
+Repository = "https://github.com/nbuchwitz/ptouch"
+Issues = "https://github.com/nbuchwitz/ptouch/issues"
+
 [project.optional-dependencies]
 usb = ["pyusb"]
 dev = ["ruff", "mypy"]
 test = ["pytest", "pytest-cov", "pyusb"]
+docs = [
+    "sphinx>=7.0",
+    "sphinx-rtd-theme>=2.0",
+    "sphinx-autodoc-typehints>=1.24",
+]
 
 [project.scripts]
 ptouch = "ptouch.__main__:main"


### PR DESCRIPTION
## Summary

This PR adds Read the Docs integration for automatic documentation generation from NumPy-style docstrings.

## Changes

- Add `.readthedocs.yaml` configuration for automated builds on RTD
- Configure Sphinx with:
  - ReadTheDocs theme
  - Napoleon extension for NumPy-style docstrings
  - Autodoc for API reference generation
  - Type hints support via sphinx-autodoc-typehints
- Add `docs` optional dependency group to `pyproject.toml`
- Add project URLs (Documentation, Repository, Issues) to PyPI metadata
- Generate initial Sphinx documentation structure with comprehensive API reference

## Documentation Structure

- Connection Module (USB and Network connections)
- Printer Module (Base classes and printer implementations)
- Label Module (Text and Image labels)
- Tape Module (Tape types and configurations)
- Exception hierarchy documentation

## After Merge

1. Visit https://readthedocs.org/ and import the repository
2. Documentation will be automatically built on each commit
3. Docs will be available at: https://ptouch.readthedocs.io/

## Local Building

```bash
pip install -e ".[docs]"
cd docs && make html
```

Output: `docs/_build/html/index.html`