### PR TITLE
feat: add supported_tapes property to LabelPrinter

### DIFF
--- a/docs/api/tape.rst
+++ b/docs/api/tape.rst
@@ -97,9 +97,10 @@ Checking Tape Compatibility
 
    printer = PTE550W(connection)
 
-   try:
-       config = printer.get_tape_config(Tape36mm)
-   except KeyError:
+   # Check if tape is supported
+   if Tape36mm in printer.supported_tapes:
+       print("Tape is supported")
+   else:
        print("This tape is not compatible with this printer")
 
 Available Tape Widths
@@ -112,8 +113,7 @@ Available Tape Widths
    printer = PTP900(connection)
 
    # Get all supported tape types
-   supported_tapes = printer.PIN_CONFIGS.keys()
-   for tape_type in supported_tapes:
+   for tape_type in printer.supported_tapes:
        print(f"Supported: {tape_type.__name__} ({tape_type.width_mm}mm)")
 
 Adding Custom Tape Types

--- a/src/ptouch/printer.py
+++ b/src/ptouch/printer.py
@@ -96,6 +96,17 @@ class LabelPrinter(ABC):
         """Whether the printer supports high resolution mode."""
         return self.RESOLUTION_DPI_HIGH > 0
 
+    @property
+    def supported_tapes(self) -> list[type[Tape]]:
+        """Get list of tape types supported by this printer.
+
+        Returns
+        -------
+        list[type[Tape]]
+            List of supported tape classes, sorted by name.
+        """
+        return sorted(self.PIN_CONFIGS.keys(), key=lambda t: t.__name__)
+
     # Margin constraints in mm. See manual section "2.3.3 Feed amount".
     MIN_MARGIN_MM: float = 2.0
     MAX_MARGIN_MM: float = 127.0

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -92,6 +92,38 @@ class TestPTE550W:
             printer.get_tape_config(tape)
 
 
+class TestSupportedTapes:
+    """Test supported_tapes property."""
+
+    def test_supported_tapes_returns_list(self, mock_connection: MockConnection) -> None:
+        """Test that supported_tapes returns a list of tape classes."""
+        printer = PTE550W(mock_connection)
+        tapes = printer.supported_tapes
+        assert isinstance(tapes, list)
+        assert len(tapes) > 0
+        assert Tape6mm in tapes
+        assert Tape12mm in tapes
+        assert Tape24mm in tapes
+
+    def test_supported_tapes_sorted_by_name(self, mock_connection: MockConnection) -> None:
+        """Test that supported_tapes are sorted by class name."""
+        printer = PTE550W(mock_connection)
+        tapes = printer.supported_tapes
+        names = [t.__name__ for t in tapes]
+        assert names == sorted(names)
+
+    def test_supported_tapes_excludes_unsupported(self, mock_connection: MockConnection) -> None:
+        """Test that E550W doesn't include 36mm tape."""
+        printer = PTE550W(mock_connection)
+        tapes = printer.supported_tapes
+        assert Tape36mm not in tapes
+
+    def test_p900_supports_36mm(self, mock_connection: MockConnection) -> None:
+        """Test that P900 includes 36mm tape."""
+        printer = PTP900(mock_connection)
+        assert Tape36mm in printer.supported_tapes
+
+
 class TestPTP750W:
     """Test PTP750W printer class."""
 


### PR DESCRIPTION
## Summary
- Add `supported_tapes` property to `LabelPrinter` that returns a list of supported tape classes
- Tapes are sorted alphabetically by class name to keep tape types grouped together
- Provides a clean API for checking tape compatibility: `if Tape36mm in printer.supported_tapes`

## Test plan
- [x] Added unit tests for the new property
- [x] All 153 existing tests pass
- [x] Updated documentation with usage examples