### PR TITLE
feat: add USB device selector for multiple printers

### DIFF
--- a/docs/api/connection.rst
+++ b/docs/api/connection.rst
@@ -9,6 +9,44 @@ The connection module provides connection implementations for USB and network co
    :show-inheritance:
    :member-order: bysource
 
+USB Device Selection
+--------------------
+
+When multiple USB printers are connected, you can select a specific device using:
+
+* ``product_id`` - USB product ID to match a specific printer model
+* ``serial`` - USB serial number to match a specific device
+
+Example:
+
+.. code-block:: python
+
+   from ptouch import ConnectionUSB
+
+   # Connect to specific device by serial number
+   connection = ConnectionUSB(product_id=0x2086, serial="A1B2C3D4E5")
+
+USB URI Format
+~~~~~~~~~~~~~~
+
+The ``parse_usb_uri`` function parses USB device URIs for CLI usage:
+
+.. code-block:: python
+
+   from ptouch import parse_usb_uri
+
+   # Parse various URI formats
+   vendor, product, serial = parse_usb_uri("usb://0x04f9:0x2086/A1B2C3D4E5")
+   vendor, product, serial = parse_usb_uri("usb://:0x2086/A1B2C3D4E5")
+   vendor, product, serial = parse_usb_uri("usb://:0x2086")
+
+Supported formats:
+
+* ``usb://vendor:product`` - Vendor and product ID
+* ``usb://vendor:product/serial`` - With serial number
+* ``usb://:product`` - Product ID only (default vendor)
+* ``usb://:product/serial`` - Product and serial (default vendor)
+
 Exception Classes
 -----------------
 

--- a/docs/userguide.rst
+++ b/docs/userguide.rst
@@ -220,10 +220,52 @@ USB Connection
    # Find first available Brother printer
    connection = ConnectionUSB()
 
-   # Specify vendor/product ID
+   # Specify product ID (vendor defaults to Brother 0x04f9)
+   connection = ConnectionUSB(product_id=0x2086)
+
+   # Connect to specific device by serial number (useful with multiple printers)
+   connection = ConnectionUSB(product_id=0x2086, serial="A1B2C3D4E5")
+
+   # Specify all parameters
    connection = ConnectionUSB(
-       vendor_id=0x04f9,  # Brother
-       product_id=0x20af  # PT-P900 series
+       vendor_id=0x04f9,
+       product_id=0x2086,
+       serial="A1B2C3D4E5"
+   )
+
+USB URI (CLI)
+~~~~~~~~~~~~~
+
+The CLI supports a URI format for specifying USB devices:
+
+.. code-block:: bash
+
+   # Basic USB connection (auto-detect)
+   ptouch "Hello" --usb --printer P950NW --tape-width 12
+
+   # Specify product ID
+   ptouch "Hello" --usb usb://:0x2086 --printer P950NW --tape-width 12
+
+   # Specify serial number (for multiple printers)
+   ptouch "Hello" --usb usb://:0x2086/A1B2C3D4E5 --printer P950NW --tape-width 12
+
+   # Full URI with vendor
+   ptouch "Hello" --usb usb://0x04f9:0x2086/A1B2C3D4E5 --printer P950NW --tape-width 12
+
+You can also parse USB URIs programmatically:
+
+.. code-block:: python
+
+   from ptouch import parse_usb_uri, ConnectionUSB
+
+   # Parse URI string
+   vendor_id, product_id, serial = parse_usb_uri("usb://:0x2086/A1B2C3D4E5")
+
+   # Create connection from parsed values
+   connection = ConnectionUSB(
+       vendor_id=vendor_id,
+       product_id=product_id,
+       serial=serial
    )
 
 Print Settings

--- a/src/ptouch/__init__.py
+++ b/src/ptouch/__init__.py
@@ -34,6 +34,7 @@ from .connection import (
     PrinterPermissionError,
     PrinterTimeoutError,
     PrinterWriteError,
+    parse_usb_uri,
 )
 from .label import Align, Label, TextLabel
 from .printer import LabelPrinter, MediaType, TapeConfig
@@ -79,6 +80,7 @@ __all__ = [
     "PrinterPermissionError",
     "PrinterTimeoutError",
     "PrinterWriteError",
+    "parse_usb_uri",
     # Printers
     "LabelPrinter",
     "PTE550W",


### PR DESCRIPTION
## Summary

- Add `parse_usb_uri()` function to parse USB device URIs
- Add `vendor_id`, `product_id`, `serial` parameters to `ConnectionUSB`
- Update CLI `--usb` to accept optional URI argument
- Serial numbers must be hex-only

## Usage

**Python API:**
```python
from ptouch import ConnectionUSB

# Connect to specific device by serial number
connection = ConnectionUSB(product_id=0x2086, serial="A1B2C3D4E5")
```

**CLI:**
```bash
# Basic USB (auto-detect)
ptouch "Test" --usb --printer P950NW --tape-width 12

# With specific device
ptouch "Test" --usb usb://:0x2086/A1B2C3D4E5 --printer P950NW --tape-width 12
```

## Test plan

- [x] Unit tests for `parse_usb_uri()` function
- [x] Unit tests for `ConnectionUSB` with new parameters
- [x] All 173 tests pass