### PR TITLE
feat: add heat shrink tube support (HSe series)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A Python library for Brother P-touch label printers.
 - Text labels with customizable fonts and alignment
 - Image label printing
 - Multi-label printing with half-cut support (saves tape)
+- Heat shrink tube support (HSe 2:1 and 3:1 series on PT-P900/P900W/P950NW)
 - High resolution mode support
 - TIFF compression for efficient data transfer
 
@@ -56,9 +57,11 @@ Comprehensive documentation is available at [ptouch.readthedocs.io](https://ptou
 
 ### Tapes
 
-| Type | Widths | Class |
-|------|--------|-------|
-| TZe | 3.5mm, 6mm, 9mm, 12mm, 18mm, 24mm, 36mm | `Tape*mm` |
+| Type | Widths | Class | Notes |
+|------|--------|-------|-------|
+| TZe (Laminated) | 3.5mm, 6mm, 9mm, 12mm, 18mm, 24mm, 36mm | `Tape*mm` | All printers |
+| HSe 2:1 (Heat Shrink) | 5.8mm, 8.8mm, 11.7mm, 17.7mm, 23.6mm | `HeatShrinkTube*mm` | P900/P900W/P950NW only |
+| HSe 3:1 (Heat Shrink) | 5.2mm, 9.0mm, 11.2mm, 21.0mm, 31.0mm | `HeatShrinkTube3_1_*mm` | P900/P900W/P950NW only |
 
 ## Adding Support for New Devices
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A Python library for Brother P-touch label printers.
 - Text labels with customizable fonts and alignment
 - Image label printing
 - Multi-label printing with half-cut support (saves tape)
-- Heat shrink tube support (HSe 2:1 and 3:1 series on PT-P900/P900W/P950NW)
+- Heat shrink tube support (HSe 2:1 and 3:1 series on PT-E550W/P750W/P900/P900W/P950NW)
 - High resolution mode support
 - TIFF compression for efficient data transfer
 
@@ -60,8 +60,8 @@ Comprehensive documentation is available at [ptouch.readthedocs.io](https://ptou
 | Type | Widths | Class | Notes |
 |------|--------|-------|-------|
 | TZe (Laminated) | 3.5mm, 6mm, 9mm, 12mm, 18mm, 24mm, 36mm | `Tape*mm` | All printers |
-| HSe 2:1 (Heat Shrink) | 5.8mm, 8.8mm, 11.7mm, 17.7mm, 23.6mm | `HeatShrinkTube*mm` | P900/P900W/P950NW only |
-| HSe 3:1 (Heat Shrink) | 5.2mm, 9.0mm, 11.2mm, 21.0mm, 31.0mm | `HeatShrinkTube3_1_*mm` | P900/P900W/P950NW only |
+| HSe 2:1 (Heat Shrink) | 5.8mm, 8.8mm, 11.7mm, 17.7mm, 23.6mm | `HeatShrinkTube*mm` | E550W/P750W/P900/P900W/P950NW |
+| HSe 3:1 (Heat Shrink) | 5.2mm, 9.0mm, 11.2mm, 21.0mm, 31.0mm | `HeatShrinkTube3_1_*mm` | E550W/P750W: up to 21mm; P900: all |
 
 ## Adding Support for New Devices
 

--- a/docs/api/tape.rst
+++ b/docs/api/tape.rst
@@ -52,7 +52,7 @@ Compatibility
 HSe Series Heat Shrink Tubes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Heat shrink tubes are cylindrical media that shrink when heated to wrap around cables and wires for durable, professional labeling. Only supported on PT-P900, PT-P900W, and PT-P950NW.
+Heat shrink tubes are cylindrical media that shrink when heated to wrap around cables and wires for durable, professional labeling. Supported on PT-E550W, PT-P750W, PT-P900, PT-P900W, and PT-P950NW.
 
 Available Sizes - 2:1 Series
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -78,8 +78,12 @@ Compatibility
 +-----------+----------+----------+----------+----------+----------+
 | Tube Size | E550W    | P750W    | P900     | P900W    | P950NW   |
 +===========+==========+==========+==========+==========+==========+
-| All HSe   | ✗        | ✗        | ✓        | ✓        | ✓        |
+| 2:1 (all) | ✓        | ✓        | ✓        | ✓        | ✓        |
 +-----------+----------+----------+----------+----------+----------+
+| 3:1 (all) | ✓*       | ✓*       | ✓        | ✓        | ✓        |
++-----------+----------+----------+----------+----------+----------+
+
+\* E550W and P750W do not support the 31.0mm 3:1 tube
 
 .. note::
    PT-P910BT does **not** support heat shrink tubes due to hardware limitations.

--- a/docs/api/tape.rst
+++ b/docs/api/tape.rst
@@ -49,6 +49,61 @@ Compatibility
 | 36mm       | ✗        | ✗        | ✓        |
 +------------+----------+----------+----------+
 
+HSe Series Heat Shrink Tubes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Heat shrink tubes are cylindrical media that shrink when heated to wrap around cables and wires for durable, professional labeling. Only supported on PT-P900, PT-P900W, and PT-P950NW.
+
+Available Sizes - 2:1 Series
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* ``HeatShrinkTube5_8mm`` - 5.8mm tube (shrinks to 1/2 diameter)
+* ``HeatShrinkTube8_8mm`` - 8.8mm tube
+* ``HeatShrinkTube11_7mm`` - 11.7mm tube
+* ``HeatShrinkTube17_7mm`` - 17.7mm tube
+* ``HeatShrinkTube23_6mm`` - 23.6mm tube
+
+Available Sizes - 3:1 Series
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* ``HeatShrinkTube3_1_5_2mm`` - 5.2mm tube (shrinks to 1/3 diameter)
+* ``HeatShrinkTube3_1_9_0mm`` - 9.0mm tube
+* ``HeatShrinkTube3_1_11_2mm`` - 11.2mm tube
+* ``HeatShrinkTube3_1_21_0mm`` - 21.0mm tube
+* ``HeatShrinkTube3_1_31_0mm`` - 31.0mm tube
+
+Compatibility
+^^^^^^^^^^^^^
+
++-----------+----------+----------+----------+----------+----------+
+| Tube Size | E550W    | P750W    | P900     | P900W    | P950NW   |
++===========+==========+==========+==========+==========+==========+
+| All HSe   | ✗        | ✗        | ✓        | ✓        | ✓        |
++-----------+----------+----------+----------+----------+----------+
+
+.. note::
+   PT-P910BT does **not** support heat shrink tubes due to hardware limitations.
+
+Usage Example
+^^^^^^^^^^^^^
+
+.. code-block:: python
+
+   from ptouch import PTP900, TextLabel, HeatShrinkTube5_8mm
+   from PIL import ImageFont
+
+   printer = PTP900(connection)
+   font = ImageFont.truetype("/path/to/font.ttf", 36)
+
+   # Create label for heat shrink tube
+   label = TextLabel(
+       "ETH0",
+       HeatShrinkTube5_8mm,
+       font=font,
+       align=TextLabel.Align.CENTER
+   )
+   printer.print(label)
+
 Tape Configuration
 ------------------
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -60,7 +60,7 @@ Create matching pairs for cable ends:
 Heat Shrink Tube Cable Labels
 ------------------------------
 
-Create labels for cables using heat shrink tubes (PT-P900/P900W/P950NW only):
+Create labels for cables using heat shrink tubes (PT-E550W/P750W/P900/P900W/P950NW):
 
 .. code-block:: python
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -57,6 +57,63 @@ Create matching pairs for cable ends:
        label_b = TextLabel(cable_b, Tape9mm, font=font)
        printer.print_multi([label_a, label_b])
 
+Heat Shrink Tube Cable Labels
+------------------------------
+
+Create labels for cables using heat shrink tubes (PT-P900/P900W/P950NW only):
+
+.. code-block:: python
+
+   from ptouch import (
+       ConnectionNetwork,
+       PTP900,
+       TextLabel,
+       HeatShrinkTube5_8mm,      # 2:1 series
+       HeatShrinkTube3_1_9_0mm,  # 3:1 series
+   )
+   from PIL import ImageFont
+
+   connection = ConnectionNetwork("192.168.1.100")
+   printer = PTP900(connection)
+   font = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf", 36)
+
+   # Small cables - 2:1 heat shrink (5.8mm)
+   small_cables = ["ETH0", "ETH1", "USB", "PWR"]
+   labels = []
+   for text in small_cables:
+       label = TextLabel(
+           text,
+           HeatShrinkTube5_8mm,
+           font=font,
+           align=TextLabel.Align.CENTER
+       )
+       labels.append(label)
+
+   printer.print_multi(labels, half_cut=True)
+
+   # Larger cables - 3:1 heat shrink (9.0mm)
+   large_cables = ["MAIN POWER", "GROUND", "DATA"]
+   labels = []
+   for text in large_cables:
+       label = TextLabel(
+           text,
+           HeatShrinkTube3_1_9_0mm,
+           font=font,
+           align=TextLabel.Align.CENTER
+       )
+       labels.append(label)
+
+   printer.print_multi(labels, half_cut=True)
+
+**Available heat shrink tube sizes:**
+
+* 2:1 series (shrinks to 1/2 diameter): 5.8mm, 8.8mm, 11.7mm, 17.7mm, 23.6mm
+* 3:1 series (shrinks to 1/3 diameter): 5.2mm, 9.0mm, 11.2mm, 21.0mm, 31.0mm
+
+.. note::
+   Heat shrink tubes are cylindrical media designed to shrink when heated,
+   wrapping around cables and wires for durable, professional labeling.
+
 Server Rack Labels
 ------------------
 

--- a/src/ptouch/__init__.py
+++ b/src/ptouch/__init__.py
@@ -40,7 +40,18 @@ from .label import Align, Label, TextLabel
 from .printer import LabelPrinter, MediaType, TapeConfig
 from .printers import PTE550W, PTP750W, PTP900, PTP900W, PTP910BT, PTP950NW
 from .tape import (
-    HeatShrinkTape,
+    # Heat shrink tubes (HSe series)
+    HeatShrinkTube,
+    HeatShrinkTube3_1_5_2mm,
+    HeatShrinkTube3_1_9_0mm,
+    HeatShrinkTube3_1_11_2mm,
+    HeatShrinkTube3_1_21_0mm,
+    HeatShrinkTube3_1_31_0mm,
+    HeatShrinkTube5_8mm,
+    HeatShrinkTube8_8mm,
+    HeatShrinkTube11_7mm,
+    HeatShrinkTube17_7mm,
+    HeatShrinkTube23_6mm,
     # Deprecated aliases (use Tape*mm instead)
     LaminatedTape,
     LaminatedTape3_5mm,
@@ -98,7 +109,18 @@ __all__ = [
     "Tape18mm",
     "Tape24mm",
     "Tape36mm",
-    "HeatShrinkTape",
+    # Heat shrink tubes (HSe series)
+    "HeatShrinkTube",
+    "HeatShrinkTube5_8mm",
+    "HeatShrinkTube8_8mm",
+    "HeatShrinkTube11_7mm",
+    "HeatShrinkTube17_7mm",
+    "HeatShrinkTube23_6mm",
+    "HeatShrinkTube3_1_5_2mm",
+    "HeatShrinkTube3_1_9_0mm",
+    "HeatShrinkTube3_1_11_2mm",
+    "HeatShrinkTube3_1_21_0mm",
+    "HeatShrinkTube3_1_31_0mm",
     # Deprecated tape aliases (use Tape*mm instead)
     "LaminatedTape",
     "LaminatedTape3_5mm",

--- a/src/ptouch/printers.py
+++ b/src/ptouch/printers.py
@@ -6,6 +6,16 @@
 
 from .printer import LabelPrinter, TapeConfig
 from .tape import (
+    HeatShrinkTube3_1_5_2mm,
+    HeatShrinkTube3_1_9_0mm,
+    HeatShrinkTube3_1_11_2mm,
+    HeatShrinkTube3_1_21_0mm,
+    HeatShrinkTube3_1_31_0mm,
+    HeatShrinkTube5_8mm,
+    HeatShrinkTube8_8mm,
+    HeatShrinkTube11_7mm,
+    HeatShrinkTube17_7mm,
+    HeatShrinkTube23_6mm,
     Tape3_5mm,
     Tape6mm,
     Tape9mm,
@@ -68,6 +78,7 @@ class PTP900Series(LabelPrinter):
     # Pin configurations from official Brother PT-P900 specification document
     # Source: cv_ptp900_eng_raster_102.pdf, pages 23-24, section 2.3.5 "Raster line"
     PIN_CONFIGS = {
+        # Laminated tapes (TZe series)
         Tape3_5mm: TapeConfig(left_pins=248, print_pins=48, right_pins=264),
         Tape6mm: TapeConfig(left_pins=240, print_pins=64, right_pins=256),
         Tape9mm: TapeConfig(left_pins=219, print_pins=106, right_pins=235),
@@ -75,6 +86,19 @@ class PTP900Series(LabelPrinter):
         Tape18mm: TapeConfig(left_pins=155, print_pins=234, right_pins=171),
         Tape24mm: TapeConfig(left_pins=112, print_pins=320, right_pins=128),
         Tape36mm: TapeConfig(left_pins=45, print_pins=454, right_pins=61),
+        # Heat shrink tubes 2:1 series (HSe)
+        # Corrected configs: shifted +17 pins down based on Brother software analysis
+        HeatShrinkTube5_8mm: TapeConfig(left_pins=261, print_pins=56, right_pins=243),
+        HeatShrinkTube8_8mm: TapeConfig(left_pins=241, print_pins=96, right_pins=223),
+        HeatShrinkTube11_7mm: TapeConfig(left_pins=223, print_pins=132, right_pins=205),
+        HeatShrinkTube17_7mm: TapeConfig(left_pins=183, print_pins=212, right_pins=165),
+        HeatShrinkTube23_6mm: TapeConfig(left_pins=161, print_pins=256, right_pins=143),
+        # Heat shrink tubes 3:1 series (HSe)
+        HeatShrinkTube3_1_5_2mm: TapeConfig(left_pins=269, print_pins=40, right_pins=251),
+        HeatShrinkTube3_1_9_0mm: TapeConfig(left_pins=245, print_pins=88, right_pins=227),
+        HeatShrinkTube3_1_11_2mm: TapeConfig(left_pins=239, print_pins=100, right_pins=221),
+        HeatShrinkTube3_1_21_0mm: TapeConfig(left_pins=169, print_pins=240, right_pins=151),
+        HeatShrinkTube3_1_31_0mm: TapeConfig(left_pins=109, print_pins=360, right_pins=91),
     }
 
 
@@ -97,6 +121,20 @@ class PTP950NW(PTP900Series):
 
 
 class PTP910BT(PTP900Series):
-    """Brother PT-P910BT label printer (with Bluetooth)."""
+    """Brother PT-P910BT label printer (with Bluetooth).
+
+    Note: PT-P910BT does NOT support heat shrink tubes (HSe series).
+    """
 
     USB_PRODUCT_ID = 0x20C7
+
+    # PT-P910BT only supports laminated tapes, not heat shrink tubes
+    PIN_CONFIGS = {
+        Tape3_5mm: TapeConfig(left_pins=248, print_pins=48, right_pins=264),
+        Tape6mm: TapeConfig(left_pins=240, print_pins=64, right_pins=256),
+        Tape9mm: TapeConfig(left_pins=219, print_pins=106, right_pins=235),
+        Tape12mm: TapeConfig(left_pins=197, print_pins=150, right_pins=213),
+        Tape18mm: TapeConfig(left_pins=155, print_pins=234, right_pins=171),
+        Tape24mm: TapeConfig(left_pins=112, print_pins=320, right_pins=128),
+        Tape36mm: TapeConfig(left_pins=45, print_pins=454, right_pins=61),
+    }

--- a/src/ptouch/printers.py
+++ b/src/ptouch/printers.py
@@ -44,12 +44,26 @@ class PTE550W(LabelPrinter):
     # Pin configurations from official Brother PT-E550W specification document
     # Source: cv_pte550wp750wp710bt_eng_raster_102.pdf, page 20, section "2.3 Print Area"
     PIN_CONFIGS = {
+        # Laminated tapes (TZe series)
         Tape3_5mm: TapeConfig(left_pins=52, print_pins=24, right_pins=52),
         Tape6mm: TapeConfig(left_pins=48, print_pins=32, right_pins=48),
         Tape9mm: TapeConfig(left_pins=39, print_pins=50, right_pins=39),
         Tape12mm: TapeConfig(left_pins=29, print_pins=70, right_pins=29),
         Tape18mm: TapeConfig(left_pins=8, print_pins=112, right_pins=8),
         Tape24mm: TapeConfig(left_pins=0, print_pins=128, right_pins=0),
+        # Heat shrink tubes 2:1 series (HSe)
+        # Source: cv_pte550wp750wp710bt_eng_raster_102.pdf, page 20, section "2.3 Print Area"
+        HeatShrinkTube5_8mm: TapeConfig(left_pins=50, print_pins=28, right_pins=50),
+        HeatShrinkTube8_8mm: TapeConfig(left_pins=40, print_pins=48, right_pins=40),
+        HeatShrinkTube11_7mm: TapeConfig(left_pins=31, print_pins=66, right_pins=31),
+        HeatShrinkTube17_7mm: TapeConfig(left_pins=11, print_pins=106, right_pins=11),
+        HeatShrinkTube23_6mm: TapeConfig(left_pins=0, print_pins=128, right_pins=0),
+        # Heat shrink tubes 3:1 series (HSe)
+        HeatShrinkTube3_1_5_2mm: TapeConfig(left_pins=54, print_pins=20, right_pins=54),
+        HeatShrinkTube3_1_9_0mm: TapeConfig(left_pins=42, print_pins=44, right_pins=42),
+        HeatShrinkTube3_1_11_2mm: TapeConfig(left_pins=39, print_pins=50, right_pins=39),
+        HeatShrinkTube3_1_21_0mm: TapeConfig(left_pins=4, print_pins=120, right_pins=4),
+        # Note: PT-E550W/P750W do NOT support 31.0mm 3:1 tubes
     }
 
 

--- a/src/ptouch/printers.py
+++ b/src/ptouch/printers.py
@@ -52,17 +52,17 @@ class PTE550W(LabelPrinter):
         Tape18mm: TapeConfig(left_pins=8, print_pins=112, right_pins=8),
         Tape24mm: TapeConfig(left_pins=0, print_pins=128, right_pins=0),
         # Heat shrink tubes 2:1 series (HSe)
-        # Source: cv_pte550wp750wp710bt_eng_raster_102.pdf, page 20, section "2.3 Print Area"
-        HeatShrinkTube5_8mm: TapeConfig(left_pins=50, print_pins=28, right_pins=50),
-        HeatShrinkTube8_8mm: TapeConfig(left_pins=40, print_pins=48, right_pins=40),
-        HeatShrinkTube11_7mm: TapeConfig(left_pins=31, print_pins=66, right_pins=31),
-        HeatShrinkTube17_7mm: TapeConfig(left_pins=11, print_pins=106, right_pins=11),
+        # Corrected configs: shifted -2 pins (up) based on testing
+        HeatShrinkTube5_8mm: TapeConfig(left_pins=52, print_pins=28, right_pins=48),
+        HeatShrinkTube8_8mm: TapeConfig(left_pins=42, print_pins=48, right_pins=38),
+        HeatShrinkTube11_7mm: TapeConfig(left_pins=33, print_pins=66, right_pins=29),
+        HeatShrinkTube17_7mm: TapeConfig(left_pins=13, print_pins=106, right_pins=9),
         HeatShrinkTube23_6mm: TapeConfig(left_pins=0, print_pins=128, right_pins=0),
         # Heat shrink tubes 3:1 series (HSe)
-        HeatShrinkTube3_1_5_2mm: TapeConfig(left_pins=54, print_pins=20, right_pins=54),
-        HeatShrinkTube3_1_9_0mm: TapeConfig(left_pins=42, print_pins=44, right_pins=42),
-        HeatShrinkTube3_1_11_2mm: TapeConfig(left_pins=39, print_pins=50, right_pins=39),
-        HeatShrinkTube3_1_21_0mm: TapeConfig(left_pins=4, print_pins=120, right_pins=4),
+        HeatShrinkTube3_1_5_2mm: TapeConfig(left_pins=56, print_pins=20, right_pins=52),
+        HeatShrinkTube3_1_9_0mm: TapeConfig(left_pins=44, print_pins=44, right_pins=40),
+        HeatShrinkTube3_1_11_2mm: TapeConfig(left_pins=41, print_pins=50, right_pins=37),
+        HeatShrinkTube3_1_21_0mm: TapeConfig(left_pins=6, print_pins=120, right_pins=2),
         # Note: PT-E550W/P750W do NOT support 31.0mm 3:1 tubes
     }
 

--- a/src/ptouch/tape.py
+++ b/src/ptouch/tape.py
@@ -67,14 +67,86 @@ class Tape36mm(Tape):
     width_mm = 36
 
 
-class HeatShrinkTape(Tape):
-    """Base class for heat shrink tube tapes (HSe series).
+class HeatShrinkTube(Tape):
+    """Base class for heat shrink tubes (HSe series).
 
     Heat shrink tubes shrink when heated to wrap around cables and wires.
     They have different printable area constraints than laminated tapes.
+
+    Note: Heat shrink tubes are NOT supported on PT-P910BT.
     """
 
     pass
+
+
+# =============================================================================
+# Heat Shrink Tube 2:1 Series (shrinks to 1/2 original diameter)
+# =============================================================================
+
+
+class HeatShrinkTube5_8mm(HeatShrinkTube):
+    """5.8mm heat shrink tube (2:1 series)."""
+
+    width_mm = 6  # Media size reported by printer
+
+
+class HeatShrinkTube8_8mm(HeatShrinkTube):
+    """8.8mm heat shrink tube (2:1 series)."""
+
+    width_mm = 9  # Media size reported by printer
+
+
+class HeatShrinkTube11_7mm(HeatShrinkTube):
+    """11.7mm heat shrink tube (2:1 series)."""
+
+    width_mm = 12  # Media size reported by printer
+
+
+class HeatShrinkTube17_7mm(HeatShrinkTube):
+    """17.7mm heat shrink tube (2:1 series)."""
+
+    width_mm = 18  # Media size reported by printer
+
+
+class HeatShrinkTube23_6mm(HeatShrinkTube):
+    """23.6mm heat shrink tube (2:1 series)."""
+
+    width_mm = 24  # Media size reported by printer
+
+
+# =============================================================================
+# Heat Shrink Tube 3:1 Series (shrinks to 1/3 original diameter)
+# =============================================================================
+
+
+class HeatShrinkTube3_1_5_2mm(HeatShrinkTube):
+    """5.2mm heat shrink tube (3:1 series)."""
+
+    width_mm = 5  # Media size reported by printer
+
+
+class HeatShrinkTube3_1_9_0mm(HeatShrinkTube):
+    """9.0mm heat shrink tube (3:1 series)."""
+
+    width_mm = 9  # Media size reported by printer
+
+
+class HeatShrinkTube3_1_11_2mm(HeatShrinkTube):
+    """11.2mm heat shrink tube (3:1 series)."""
+
+    width_mm = 11  # Media size reported by printer
+
+
+class HeatShrinkTube3_1_21_0mm(HeatShrinkTube):
+    """21.0mm heat shrink tube (3:1 series)."""
+
+    width_mm = 21  # Media size reported by printer
+
+
+class HeatShrinkTube3_1_31_0mm(HeatShrinkTube):
+    """31.0mm heat shrink tube (3:1 series)."""
+
+    width_mm = 31  # Media size reported by printer
 
 
 # =============================================================================

--- a/tests/test_tape.py
+++ b/tests/test_tape.py
@@ -7,7 +7,17 @@
 import pytest
 
 from ptouch.tape import (
-    HeatShrinkTape,
+    HeatShrinkTube,
+    HeatShrinkTube3_1_5_2mm,
+    HeatShrinkTube3_1_9_0mm,
+    HeatShrinkTube3_1_11_2mm,
+    HeatShrinkTube3_1_21_0mm,
+    HeatShrinkTube3_1_31_0mm,
+    HeatShrinkTube5_8mm,
+    HeatShrinkTube8_8mm,
+    HeatShrinkTube11_7mm,
+    HeatShrinkTube17_7mm,
+    HeatShrinkTube23_6mm,
     LaminatedTape,
     LaminatedTape3_5mm,
     LaminatedTape6mm,
@@ -67,9 +77,9 @@ class TestTapeWidths:
 class TestTapeInheritance:
     """Test tape class inheritance."""
 
-    def test_heat_shrink_tape_inherits_from_tape(self) -> None:
-        """Test that HeatShrinkTape inherits from Tape."""
-        assert issubclass(HeatShrinkTape, Tape)
+    def test_heat_shrink_tube_inherits_from_tape(self) -> None:
+        """Test that HeatShrinkTube inherits from Tape."""
+        assert issubclass(HeatShrinkTube, Tape)
 
     @pytest.mark.parametrize(
         "tape_class",
@@ -158,3 +168,110 @@ class TestDeprecatedAliases:
         """Test that deprecated aliases are subclasses of their new counterparts."""
         assert issubclass(deprecated_class, new_class)
         assert issubclass(deprecated_class, Tape)
+
+
+class TestHeatShrinkTubeWidths:
+    """Test heat shrink tube width attributes."""
+
+    @pytest.mark.parametrize(
+        "tube_class,expected_width",
+        [
+            # 2:1 series
+            (HeatShrinkTube5_8mm, 6),
+            (HeatShrinkTube8_8mm, 9),
+            (HeatShrinkTube11_7mm, 12),
+            (HeatShrinkTube17_7mm, 18),
+            (HeatShrinkTube23_6mm, 24),
+            # 3:1 series
+            (HeatShrinkTube3_1_5_2mm, 5),
+            (HeatShrinkTube3_1_9_0mm, 9),
+            (HeatShrinkTube3_1_11_2mm, 11),
+            (HeatShrinkTube3_1_21_0mm, 21),
+            (HeatShrinkTube3_1_31_0mm, 31),
+        ],
+    )
+    def test_heat_shrink_tube_width(
+        self, tube_class: type[HeatShrinkTube], expected_width: int
+    ) -> None:
+        """Test that heat shrink tube classes have correct width_mm."""
+        tube = tube_class()
+        assert tube.width_mm == expected_width
+
+    @pytest.mark.parametrize(
+        "tube_class,expected_width",
+        [
+            # 2:1 series
+            (HeatShrinkTube5_8mm, 6),
+            (HeatShrinkTube8_8mm, 9),
+            (HeatShrinkTube11_7mm, 12),
+            (HeatShrinkTube17_7mm, 18),
+            (HeatShrinkTube23_6mm, 24),
+            # 3:1 series
+            (HeatShrinkTube3_1_5_2mm, 5),
+            (HeatShrinkTube3_1_9_0mm, 9),
+            (HeatShrinkTube3_1_11_2mm, 11),
+            (HeatShrinkTube3_1_21_0mm, 21),
+            (HeatShrinkTube3_1_31_0mm, 31),
+        ],
+    )
+    def test_heat_shrink_tube_width_class_attribute(
+        self, tube_class: type[HeatShrinkTube], expected_width: int
+    ) -> None:
+        """Test that width_mm is accessible as class attribute."""
+        assert tube_class.width_mm == expected_width
+
+
+class TestHeatShrinkTubeInheritance:
+    """Test heat shrink tube class inheritance."""
+
+    @pytest.mark.parametrize(
+        "tube_class",
+        [
+            # 2:1 series
+            HeatShrinkTube5_8mm,
+            HeatShrinkTube8_8mm,
+            HeatShrinkTube11_7mm,
+            HeatShrinkTube17_7mm,
+            HeatShrinkTube23_6mm,
+            # 3:1 series
+            HeatShrinkTube3_1_5_2mm,
+            HeatShrinkTube3_1_9_0mm,
+            HeatShrinkTube3_1_11_2mm,
+            HeatShrinkTube3_1_21_0mm,
+            HeatShrinkTube3_1_31_0mm,
+        ],
+    )
+    def test_heat_shrink_tube_inherits_from_heat_shrink_tube_base(
+        self, tube_class: type[HeatShrinkTube]
+    ) -> None:
+        """Test that all heat shrink tube sizes inherit from HeatShrinkTube."""
+        assert issubclass(tube_class, HeatShrinkTube)
+        assert issubclass(tube_class, Tape)
+
+
+class TestHeatShrinkTubeInstantiation:
+    """Test heat shrink tube instantiation."""
+
+    @pytest.mark.parametrize(
+        "tube_class",
+        [
+            # 2:1 series
+            HeatShrinkTube5_8mm,
+            HeatShrinkTube8_8mm,
+            HeatShrinkTube11_7mm,
+            HeatShrinkTube17_7mm,
+            HeatShrinkTube23_6mm,
+            # 3:1 series
+            HeatShrinkTube3_1_5_2mm,
+            HeatShrinkTube3_1_9_0mm,
+            HeatShrinkTube3_1_11_2mm,
+            HeatShrinkTube3_1_21_0mm,
+            HeatShrinkTube3_1_31_0mm,
+        ],
+    )
+    def test_heat_shrink_tube_can_be_instantiated(self, tube_class: type[HeatShrinkTube]) -> None:
+        """Test that heat shrink tube classes can be instantiated."""
+        tube = tube_class()
+        assert isinstance(tube, tube_class)
+        assert isinstance(tube, HeatShrinkTube)
+        assert isinstance(tube, Tape)


### PR DESCRIPTION
## Summary

- Add support for HSe heat shrink tubes (2:1 and 3:1 series) on PT-P900/P900W/P950NW
- Add media type detection in `_get_media_type()` (0x11 for HSe 2:1, 0x17 for HSe 3:1)
- Add pin configurations for all HSe tube sizes with +17 pin offset correction
- Update README with heat shrink tube information
- Add comprehensive documentation with usage examples and compatibility matrix

## Supported Tubes

**2:1 Series (shrinks to 1/2 diameter):**
5.8mm, 8.8mm, 11.7mm, 17.7mm, 23.6mm

**3:1 Series (shrinks to 1/3 diameter):**
5.2mm, 9.0mm, 11.2mm, 21.0mm, 31.0mm

## Technical Details

Heat shrink tube pin configurations use +17 pin downward shift from official Brother specifications. This correction was determined empirically by analyzing Brother Windows software output to achieve proper vertical centering on cylindrical media.

PT-P910BT does not support heat shrink tubes due to hardware limitations.

## Test plan

- [x] All 213 tests pass
- [x] Verified on PT-P900 hardware with multiple tube sizes
- [x] Documentation includes usage examples and compatibility information